### PR TITLE
feat: filtrer la recherche sur livres, auteurs et critiques uniquement (issue #13)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/data/repository/SearchRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/SearchRepository.kt
@@ -14,7 +14,7 @@ class SearchRepository(
             .filter { it.isNotBlank() }
             .joinToString(" ") { "$it*" }
         val sql = SimpleSQLiteQuery(
-            "SELECT type, ref_id AS refId, content FROM search_index WHERE search_index MATCH ? LIMIT 50",
+            "SELECT type, ref_id AS refId, content FROM search_index WHERE search_index MATCH ? AND type IN ('livre', 'auteur', 'critique') LIMIT 50",
             arrayOf(ftsQuery)
         )
         return searchDao.searchRaw(sql).map {

--- a/app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt
@@ -78,7 +78,7 @@ fun SearchContent(
             onSearch = {},
             active = false,
             onActiveChange = {},
-            placeholder = { Text("Rechercher un livre, auteur, émission...") },
+            placeholder = { Text("Rechercher un livre, auteur, critique...") },
             leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
             modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)
         ) {}

--- a/app/src/test/java/com/lmelp/mobile/SearchFilterTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/SearchFilterTest.kt
@@ -1,0 +1,87 @@
+package com.lmelp.mobile
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests pour le filtrage des types de résultats de recherche.
+ *
+ * Seuls les types autorisés sont retournés : 'livre', 'auteur', 'critique'.
+ * Les 'emission' et autres types sont exclus.
+ */
+class SearchFilterTest {
+
+    private val typesAutorises = setOf("livre", "auteur", "critique")
+
+    data class FakeResult(val type: String, val content: String)
+
+    private fun filtrerResultats(resultats: List<FakeResult>): List<FakeResult> =
+        resultats.filter { it.type in typesAutorises }
+
+    // --- Types inclus ---
+
+    @Test
+    fun `livre est inclus dans les résultats`() {
+        val resultats = listOf(FakeResult("livre", "Le Grand Meaulnes"))
+        assertEquals(1, filtrerResultats(resultats).size)
+    }
+
+    @Test
+    fun `auteur est inclus dans les résultats`() {
+        val resultats = listOf(FakeResult("auteur", "Alain-Fournier"))
+        assertEquals(1, filtrerResultats(resultats).size)
+    }
+
+    @Test
+    fun `critique est inclus dans les résultats`() {
+        val resultats = listOf(FakeResult("critique", "Jérôme Garcin"))
+        assertEquals(1, filtrerResultats(resultats).size)
+    }
+
+    // --- Types exclus ---
+
+    @Test
+    fun `emission est exclu des résultats`() {
+        val resultats = listOf(FakeResult("emission", "Émission du 01/01/2024"))
+        assertTrue(filtrerResultats(resultats).isEmpty())
+    }
+
+    @Test
+    fun `type inconnu est exclu des résultats`() {
+        val resultats = listOf(FakeResult("editeur", "Gallimard"))
+        assertTrue(filtrerResultats(resultats).isEmpty())
+    }
+
+    // --- Filtrage d'une liste mixte ---
+
+    @Test
+    fun `filtre une liste mixte et ne garde que les types autorisés`() {
+        val resultats = listOf(
+            FakeResult("livre",    "Le Petit Prince"),
+            FakeResult("emission", "Émission 2024"),
+            FakeResult("auteur",   "Saint-Exupéry"),
+            FakeResult("critique", "Jérôme Garcin"),
+            FakeResult("editeur",  "Gallimard"),
+        )
+        val filtrés = filtrerResultats(resultats)
+        assertEquals(3, filtrés.size)
+        assertTrue(filtrés.none { it.type == "emission" })
+        assertTrue(filtrés.none { it.type == "editeur" })
+    }
+
+    @Test
+    fun `liste sans émissions est inchangée`() {
+        val resultats = listOf(
+            FakeResult("livre",    "Candide"),
+            FakeResult("auteur",   "Voltaire"),
+            FakeResult("critique", "Nelly Kaprièlian"),
+        )
+        assertEquals(3, filtrerResultats(resultats).size)
+    }
+
+    @Test
+    fun `liste vide retourne liste vide`() {
+        assertTrue(filtrerResultats(emptyList()).isEmpty())
+    }
+}

--- a/docs/claude/memory/260309-1100-issue13-recherche-filtrage-types.md
+++ b/docs/claude/memory/260309-1100-issue13-recherche-filtrage-types.md
@@ -1,0 +1,43 @@
+# Issue #13 — Recherche : filtrer les types de résultats
+
+Date : 2026-03-09
+Branche : `13-recherche-ne-le-faire-que-pour-les-livres-auteurs-et-avis-des-critiques`
+
+## Comportement
+
+La recherche FTS5 n'affiche plus les résultats de type `emission`.
+Seuls les types `livre`, `auteur`, `critique` sont retournés.
+
+## Implémentation — un seul fichier modifié côté logique
+
+### `app/src/main/java/com/lmelp/mobile/data/repository/SearchRepository.kt`
+
+Ajout de `AND type IN ('livre', 'auteur', 'critique')` dans la requête SQL FTS5 :
+
+```kotlin
+val sql = SimpleSQLiteQuery(
+    "SELECT type, ref_id AS refId, content FROM search_index WHERE search_index MATCH ? AND type IN ('livre', 'auteur', 'critique') LIMIT 50",
+    arrayOf(ftsQuery)
+)
+```
+
+### `app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt:81`
+
+Placeholder mis à jour : `"Rechercher un livre, auteur, émission..."` → `"Rechercher un livre, auteur, critique..."`
+
+## Tests
+
+`app/src/test/java/com/lmelp/mobile/SearchFilterTest.kt` — 8 tests unitaires purs (JUnit, pas Android) :
+- livre / auteur / critique → inclus
+- emission → exclu
+- type inconnu (editeur) → exclu
+- liste mixte : 3/5 gardés
+- liste sans émissions → inchangée
+- liste vide → vide
+
+## Points clés
+
+- La table FTS5 `search_index` contient les types : `emission`, `livre`, `auteur`, `critique`
+- Le filtre est appliqué côté SQL (pas côté Kotlin) → efficace, pas de données inutiles chargées
+- `AND type IN (...)` est compatible avec la syntaxe FTS5 SQLite (le filtre porte sur une colonne normale, pas sur le contenu indexé)
+- Aucune modification du DAO ni du ViewModel


### PR DESCRIPTION
## Summary

- La recherche n'affiche plus les résultats de type `emission`
- Seuls les types `livre`, `auteur`, `critique` sont retournés
- Filtre appliqué côté SQL : `AND type IN ('livre', 'auteur', 'critique')` dans la requête FTS5
- Placeholder de la barre de recherche mis à jour : "...émission..." → "...critique..."

## Test plan

- [ ] Lancer l'app et effectuer une recherche
- [ ] Vérifier qu'aucun résultat de type "Emission" n'apparaît
- [ ] Vérifier que les livres, auteurs et critiques s'affichent toujours
- [ ] Tests unitaires : `./gradlew :app:testDebugUnitTest` → 8 nouveaux tests dans `SearchFilterTest`

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)