### PR TITLE
feat: fast scroll avec dates dans l'écran Émissions (issue #20)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/EmissionsScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/EmissionsScreen.kt
@@ -1,15 +1,27 @@
 package com.lmelp.mobile.ui.emissions
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -18,11 +30,23 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import com.lmelp.mobile.ui.theme.LmelpBleu
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.lmelp.mobile.data.model.EmissionUi
@@ -30,8 +54,23 @@ import com.lmelp.mobile.data.repository.EmissionsRepository
 import com.lmelp.mobile.ui.components.EmptyState
 import com.lmelp.mobile.ui.components.ErrorMessage
 import com.lmelp.mobile.ui.components.LoadingIndicator
+import com.lmelp.mobile.ui.theme.LmelpBleu
 import com.lmelp.mobile.viewmodel.EmissionsUiState
 import com.lmelp.mobile.viewmodel.EmissionsViewModel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private val MOIS_FR = listOf(
+    "Jan.", "Fév.", "Mar.", "Avr.", "Mai", "Juin",
+    "Juil.", "Août", "Sep.", "Oct.", "Nov.", "Déc."
+)
+
+private fun formatYearMonth(yearMonth: String): String {
+    val parts = yearMonth.split("-")
+    val year = parts[0].toInt()
+    val month = parts[1].toInt()
+    return "${MOIS_FR[month - 1]} $year"
+}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -70,9 +109,219 @@ fun EmissionsContent(
         uiState.isLoading -> LoadingIndicator(modifier)
         uiState.error != null -> ErrorMessage(uiState.error, modifier)
         uiState.emissions.isEmpty() -> EmptyState("Aucune émission", modifier)
-        else -> LazyColumn(modifier = modifier) {
-            items(uiState.emissions, key = { it.id }) { emission ->
+        else -> EmissionsListWithFastScroll(
+            emissions = uiState.emissions,
+            onEmissionClick = onEmissionClick,
+            modifier = modifier
+        )
+    }
+}
+
+@Composable
+fun EmissionsListWithFastScroll(
+    emissions: List<EmissionUi>,
+    onEmissionClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val listState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+
+    // Calcul des indices de début de chaque mois
+    val monthIndices: List<Pair<String, Int>> = remember(emissions) {
+        emissions.mapIndexedNotNull { index, e ->
+            val ym = e.date.take(7)
+            if (index == 0 || e.date.take(7) != emissions[index - 1].date.take(7))
+                ym to index
+            else
+                null
+        }
+    }
+
+    // Mois courant selon le premier item visible
+    val currentYearMonth by remember {
+        derivedStateOf {
+            val firstVisible = listState.firstVisibleItemIndex
+            monthIndices.lastOrNull { it.second <= firstVisible }?.first
+                ?: monthIndices.firstOrNull()?.first
+                ?: ""
+        }
+    }
+
+    // Contrôle de la visibilité de la bulle (disparaît 2s après la fin du scroll/drag)
+    var showLabel by remember { mutableStateOf(false) }
+    var isDragging by remember { mutableStateOf(false) }
+    var dragFraction by remember { mutableFloatStateOf(0f) }
+    var barHeightPx by remember { mutableFloatStateOf(1f) }
+
+    // Afficher la bulle quand le scroll bouge, la masquer 2s après arrêt
+    val isScrollInProgress = listState.isScrollInProgress
+    LaunchedEffect(isScrollInProgress, isDragging) {
+        if (isScrollInProgress || isDragging) {
+            showLabel = true
+        } else {
+            delay(2000)
+            showLabel = false
+        }
+    }
+
+    // Mois affiché dans la bulle : pendant drag = mois cible, sinon = mois courant
+    val hoveredYearMonth: String = remember(dragFraction, monthIndices) {
+        if (monthIndices.isEmpty()) return@remember ""
+        val idx = (dragFraction * monthIndices.size).toInt().coerceIn(0, monthIndices.size - 1)
+        monthIndices[idx].first
+    }
+
+    val labelToShow = if (isDragging) hoveredYearMonth else currentYearMonth
+
+    // Fraction verticale de la bulle (0..1)
+    val labelFraction = if (isDragging) dragFraction else {
+        if (monthIndices.size > 1) {
+            val cur = monthIndices.indexOfFirst { it.first == currentYearMonth }
+            if (cur >= 0) cur.toFloat() / (monthIndices.size - 1) else 0f
+        } else 0f
+    }
+
+    // Handler partagé pour le drag (utilisé à la fois par la barre et la bulle)
+    // startFraction : fraction de départ du geste (0..1 dans la barre)
+    fun onDragStart(startFractionY: Float) {
+        isDragging = true
+        showLabel = true
+        dragFraction = startFractionY.coerceIn(0f, 1f)
+    }
+
+    // dragDelta : déplacement en pixels depuis le dernier événement
+    fun onDragDelta(dragDeltaPx: Float) {
+        dragFraction = (dragFraction + dragDeltaPx / barHeightPx).coerceIn(0f, 1f)
+        if (monthIndices.isNotEmpty()) {
+            val idx = (dragFraction * monthIndices.size)
+                .toInt()
+                .coerceIn(0, monthIndices.size - 1)
+            coroutineScope.launch {
+                listState.scrollToItem(monthIndices[idx].second)
+            }
+        }
+    }
+
+    fun onDragEnd() {
+        isDragging = false
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
+        // Liste principale avec padding à droite pour ne pas passer sous la barre
+        LazyColumn(
+            state = listState,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(end = 20.dp)
+        ) {
+            items(emissions, key = { it.id }) { emission ->
                 EmissionCard(emission = emission, onClick = { onEmissionClick(emission.id) })
+            }
+        }
+
+        // Barre de fast scroll à droite (rail + pouce)
+        Box(
+            modifier = Modifier
+                .align(Alignment.CenterEnd)
+                .fillMaxHeight()
+                .width(20.dp)
+                .onSizeChanged { barHeightPx = it.height.toFloat().coerceAtLeast(1f) }
+                .pointerInput(monthIndices) {
+                    detectTapGestures { offset ->
+                        // Tap direct sur la barre → scroll immédiat à cet endroit
+                        val fraction = (offset.y / barHeightPx).coerceIn(0f, 1f)
+                        if (monthIndices.isNotEmpty()) {
+                            val idx = (fraction * monthIndices.size)
+                                .toInt()
+                                .coerceIn(0, monthIndices.size - 1)
+                            showLabel = true
+                            dragFraction = fraction
+                            coroutineScope.launch {
+                                listState.scrollToItem(monthIndices[idx].second)
+                            }
+                        }
+                    }
+                }
+                .pointerInput(monthIndices) {
+                    detectVerticalDragGestures(
+                        onDragStart = { offset ->
+                            onDragStart(offset.y / barHeightPx)
+                        },
+                        onDragEnd = { onDragEnd() },
+                        onDragCancel = { onDragEnd() },
+                        onVerticalDrag = { change, dragAmount ->
+                            change.consume()
+                            onDragDelta(dragAmount)
+                        }
+                    )
+                }
+        ) {
+            // Rail vertical
+            Box(
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .fillMaxHeight()
+                    .width(4.dp)
+                    .clip(RoundedCornerShape(2.dp))
+                    .background(MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f))
+            )
+
+            // Pouce sur le rail
+            val thumbFraction = if (isDragging) dragFraction else {
+                if (monthIndices.size > 1) {
+                    val cur = monthIndices.indexOfFirst { it.first == currentYearMonth }
+                    if (cur >= 0) cur.toFloat() / (monthIndices.size - 1) else 0f
+                } else 0f
+            }
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopCenter)
+                    .offset {
+                        IntOffset(
+                            0,
+                            (thumbFraction * barHeightPx).toInt()
+                                .coerceAtMost((barHeightPx - 24).toInt().coerceAtLeast(0))
+                        )
+                    }
+                    .width(8.dp)
+                    .wrapContentHeight()
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(LmelpBleu)
+                    .padding(vertical = 12.dp)
+            )
+        }
+
+        // Bulle mois/an — draggable, disparaît 2s après arrêt
+        if (showLabel && labelToShow.isNotEmpty() && monthIndices.size > 1) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset {
+                        val y = (labelFraction * barHeightPx).toInt()
+                            .coerceAtMost((barHeightPx - 60).toInt().coerceAtLeast(0))
+                        IntOffset(x = -24, y = y)
+                    }
+                    // La bulle est une poignée de navigation : drag par delta
+                    .pointerInput(Unit) {
+                        detectDragGestures(
+                            onDragStart = { _ -> onDragStart(labelFraction) },
+                            onDragEnd = { onDragEnd() },
+                            onDragCancel = { onDragEnd() },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                onDragDelta(dragAmount.y)
+                            }
+                        )
+                    }
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(LmelpBleu)
+                    .padding(horizontal = 8.dp, vertical = 4.dp)
+            ) {
+                Text(
+                    text = formatYearMonth(labelToShow),
+                    color = Color.White,
+                    fontSize = 12.sp
+                )
             }
         }
     }

--- a/app/src/test/java/com/lmelp/mobile/FastScrollTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/FastScrollTest.kt
@@ -1,0 +1,159 @@
+package com.lmelp.mobile
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests unitaires pour la logique du fast scroll dans l'écran Émissions.
+ *
+ * Logique testée :
+ * - calcul de monthIndices (premier index de chaque mois dans la liste)
+ * - formatage "2025-11" → "Nov. 2025"
+ */
+class FastScrollTest {
+
+    // ---- Logique de groupement par mois ----
+
+    /**
+     * Simule le calcul de monthIndices depuis une liste de dates ISO (YYYY-MM-DD).
+     * Retourne une liste de paires (yearMonth, firstIndex).
+     */
+    private fun buildMonthIndices(dates: List<String>): List<Pair<String, Int>> =
+        dates.mapIndexedNotNull { index, date ->
+            val ym = date.take(7)
+            if (index == 0 || date.take(7) != dates[index - 1].take(7))
+                ym to index
+            else
+                null
+        }
+
+    @Test
+    fun `liste vide retourne indices vides`() {
+        assertEquals(emptyList<Pair<String, Int>>(), buildMonthIndices(emptyList()))
+    }
+
+    @Test
+    fun `un seul item retourne un seul mois`() {
+        val result = buildMonthIndices(listOf("2025-11-15"))
+        assertEquals(listOf("2025-11" to 0), result)
+    }
+
+    @Test
+    fun `plusieurs items dans le meme mois retourne un seul indice`() {
+        val dates = listOf("2025-11-15", "2025-11-10", "2025-11-01")
+        val result = buildMonthIndices(dates)
+        assertEquals(listOf("2025-11" to 0), result)
+    }
+
+    @Test
+    fun `deux mois differents retournent deux indices`() {
+        val dates = listOf("2025-11-15", "2025-11-01", "2025-10-20", "2025-10-05")
+        val result = buildMonthIndices(dates)
+        assertEquals(
+            listOf("2025-11" to 0, "2025-10" to 2),
+            result
+        )
+    }
+
+    @Test
+    fun `trois mois retournent trois indices au bon premier item`() {
+        val dates = listOf(
+            "2025-11-15",
+            "2025-10-20", "2025-10-10",
+            "2025-09-30", "2025-09-15", "2025-09-01"
+        )
+        val result = buildMonthIndices(dates)
+        assertEquals(
+            listOf("2025-11" to 0, "2025-10" to 1, "2025-09" to 3),
+            result
+        )
+    }
+
+    @Test
+    fun `chaque item dans son propre mois retourne tous les indices`() {
+        val dates = listOf("2025-03-01", "2025-02-15", "2025-01-10")
+        val result = buildMonthIndices(dates)
+        assertEquals(
+            listOf("2025-03" to 0, "2025-02" to 1, "2025-01" to 2),
+            result
+        )
+    }
+
+    // ---- Formatage du libellé mois/an ----
+
+    /**
+     * Formate "YYYY-MM" en libellé localisé court (français).
+     * Ex: "2025-11" → "Nov. 2025"
+     */
+    private fun formatYearMonth(yearMonth: String): String {
+        val parts = yearMonth.split("-")
+        val year = parts[0].toInt()
+        val month = parts[1].toInt()
+        val mois = listOf(
+            "Jan.", "Fév.", "Mar.", "Avr.", "Mai", "Juin",
+            "Juil.", "Août", "Sep.", "Oct.", "Nov.", "Déc."
+        )
+        return "${mois[month - 1]} $year"
+    }
+
+    @Test
+    fun `novembre 2025 affiche Nov 2025`() {
+        assertEquals("Nov. 2025", formatYearMonth("2025-11"))
+    }
+
+    @Test
+    fun `janvier 2024 affiche Jan 2024`() {
+        assertEquals("Jan. 2024", formatYearMonth("2024-01"))
+    }
+
+    @Test
+    fun `decembre 2023 affiche Déc 2023`() {
+        assertEquals("Déc. 2023", formatYearMonth("2023-12"))
+    }
+
+    @Test
+    fun `mai 2025 affiche Mai 2025`() {
+        assertEquals("Mai 2025", formatYearMonth("2025-05"))
+    }
+
+    @Test
+    fun `juin 2025 affiche Juin 2025`() {
+        assertEquals("Juin 2025", formatYearMonth("2025-06"))
+    }
+
+    @Test
+    fun `juillet 2025 affiche Juil 2025`() {
+        assertEquals("Juil. 2025", formatYearMonth("2025-07"))
+    }
+
+    // ---- Calcul du segment de drag ----
+
+    /**
+     * Calcule l'index de mois cible en fonction de la position de drag (0f..1f)
+     * et du nombre total de mois.
+     */
+    private fun dragPositionToMonthIndex(position: Float, totalMonths: Int): Int {
+        if (totalMonths == 0) return 0
+        return (position * totalMonths).toInt().coerceIn(0, totalMonths - 1)
+    }
+
+    @Test
+    fun `drag a 0 retourne le premier mois`() {
+        assertEquals(0, dragPositionToMonthIndex(0f, 12))
+    }
+
+    @Test
+    fun `drag a 1 retourne le dernier mois`() {
+        assertEquals(11, dragPositionToMonthIndex(1f, 12))
+    }
+
+    @Test
+    fun `drag au milieu retourne le mois central`() {
+        assertEquals(6, dragPositionToMonthIndex(0.5f, 12))
+    }
+
+    @Test
+    fun `drag avec un seul mois retourne 0`() {
+        assertEquals(0, dragPositionToMonthIndex(0.9f, 1))
+    }
+}

--- a/docs/claude/memory/260309-1430-issue20-fast-scroll-emissions.md
+++ b/docs/claude/memory/260309-1430-issue20-fast-scroll-emissions.md
@@ -1,0 +1,73 @@
+# Issue #20 — Fast scroll avec dates dans l'écran Émissions
+
+Date : 2026-03-09
+Branche : `20-emissions-mettre-un-ascenseur-rapide-a-droite-avec-les-dates-des-emissions-qui-defilent`
+
+## Comportement
+
+L'écran Émissions dispose d'un **ascenseur rapide à droite** similaire aux galeries photos Android :
+
+- **Rail vertical** (4dp, gris transparent) toujours visible à droite
+- **Pouce bleu** (8dp) qui suit la position courante dans la liste
+- **Bulle "Nov. 2025"** qui apparaît pendant le scroll et disparaît 2s après arrêt
+- La bulle est **draggable** (poignée de navigation)
+- Un **tap sur la barre** positionne directement la liste au mois correspondant
+
+## Architecture
+
+### `app/src/main/java/com/lmelp/mobile/ui/emissions/EmissionsScreen.kt`
+
+Nouveau composable `EmissionsListWithFastScroll` remplace le `LazyColumn` nu :
+
+**Calcul des indices de mois** (logique pure, testée) :
+```kotlin
+val monthIndices: List<Pair<String, Int>> = remember(emissions) {
+    emissions.mapIndexedNotNull { index, e ->
+        val ym = e.date.take(7)
+        if (index == 0 || e.date.take(7) != emissions[index - 1].date.take(7))
+            ym to index else null
+    }
+}
+```
+
+**Visibilité de la bulle** (disparaît 2s après arrêt) :
+```kotlin
+LaunchedEffect(isScrollInProgress, isDragging) {
+    if (isScrollInProgress || isDragging) showLabel = true
+    else { delay(2000); showLabel = false }
+}
+```
+
+**Drag par delta** (évite les problèmes de position absolue/relative) :
+```kotlin
+fun onDragDelta(dragDeltaPx: Float) {
+    dragFraction = (dragFraction + dragDeltaPx / barHeightPx).coerceIn(0f, 1f)
+    // scroll vers monthIndices[idx]
+}
+```
+
+**Tap sur la barre** → `detectTapGestures` + `detectVerticalDragGestures` en deux `pointerInput` chaînés sur le même Box.
+
+**Bulle draggable** → `detectDragGestures` (pas vertical-only) avec `dragAmount.y`.
+
+### Formatage des dates
+
+```kotlin
+private fun formatYearMonth(yearMonth: String): String // "2025-11" → "Nov. 2025"
+private val MOIS_FR = listOf("Jan.", "Fév.", "Mar.", ...)
+```
+
+## Tests
+
+`app/src/test/java/com/lmelp/mobile/FastScrollTest.kt` — 16 tests :
+- Calcul `monthIndices` (liste vide, 1 mois, N mois, items mixtes)
+- Formatage "YYYY-MM" → libellé FR
+- Calcul du segment de drag (position 0..1 → index mois)
+
+## Points clés / pièges
+
+- **Ne pas utiliser `change.position.y`** pour le drag (position absolue relative au composable → blocage au milieu). Toujours utiliser **`dragAmount`** (delta).
+- La bulle utilise `detectDragGestures` (2D) plutôt que `detectVerticalDragGestures` car son `onDragStart` a besoin de capturer `labelFraction` au moment du début du geste.
+- Deux `pointerInput` sur le même `Box` : le premier (`detectTapGestures`) et le second (`detectVerticalDragGestures`) coexistent bien.
+- `barHeightPx` mesuré via `onSizeChanged` sur le Box de la barre.
+- `derivedStateOf` pour `currentYearMonth` évite les recompositions inutiles.


### PR DESCRIPTION
## Summary

- Barre latérale draggable à droite de la liste des émissions (rail + pouce bleu)
- Bulle "Nov. 2025" qui apparaît pendant le scroll et disparaît automatiquement après 2s
- La bulle est draggable directement (poignée de navigation rapide)
- Tap sur la barre → positionnement direct au mois correspondant

## Détails techniques

- Drag basé sur `dragAmount` (delta) et non `change.position.y` pour éviter les blocages
- `derivedStateOf` pour `currentYearMonth` (pas de recomposition inutile)
- `LaunchedEffect` + `delay(2000)` pour la disparition de la bulle
- 16 tests unitaires dans `FastScrollTest.kt`

## Test plan

- [ ] Scroller lentement : la bulle apparaît et disparaît 2s après l'arrêt
- [ ] Drag sur la barre : scroll fluide du début à la fin sans blocage
- [ ] Drag sur la bulle : navigation rapide par mois
- [ ] Tap sur la barre : positionnement direct au bon mois
- [ ] `./gradlew testDebugUnitTest` : 26 tests verts

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)