### PR TITLE
fix: corrections affichage Palmarès (issue #27)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
@@ -126,13 +126,6 @@ fun PalmaresCard(item: PalmaresUi, onClick: () -> Unit) {
                 Text(text = item.titre, style = MaterialTheme.typography.titleSmall)
                 item.auteurNom?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
             }
-            Column(horizontalAlignment = Alignment.End) {
-                NoteBadge(note = item.noteMoyenne)
-                Text(
-                    text = "${item.nbAvis} avis",
-                    style = MaterialTheme.typography.bodySmall
-                )
-            }
             if (item.calibreInLibrary) {
                 Column(horizontalAlignment = Alignment.End) {
                     Text(
@@ -140,14 +133,23 @@ fun PalmaresCard(item: PalmaresUi, onClick: () -> Unit) {
                         style = MaterialTheme.typography.bodyMedium,
                         color = if (item.calibreLu) Color(0xFF2E7D32) else Color.Gray
                     )
-                    item.calibreRating?.let {
-                        Text(
-                            text = "${it.toInt()}/10",
-                            style = MaterialTheme.typography.bodySmall,
-                            color = Color(0xFF2E7D32)
-                        )
+                    if (item.calibreLu) {
+                        item.calibreRating?.let {
+                            Text(
+                                text = "${it.toInt()}/10",
+                                style = MaterialTheme.typography.bodySmall,
+                                color = Color(0xFF2E7D32)
+                            )
+                        }
                     }
                 }
+            }
+            Column(horizontalAlignment = Alignment.End) {
+                NoteBadge(note = item.noteMoyenne)
+                Text(
+                    text = "${item.nbAvis} avis",
+                    style = MaterialTheme.typography.bodySmall
+                )
             }
         }
     }

--- a/docs/claude/memory/260309-1500-issue27-palmares-corrections-affichage.md
+++ b/docs/claude/memory/260309-1500-issue27-palmares-corrections-affichage.md
@@ -1,0 +1,39 @@
+# Issue #27 — Corrections affichage Palmarès
+
+Date : 2026-03-09
+Branche : `27-palmares-corrections-affichage`
+
+## Comportement
+
+Deux corrections dans `app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt` :
+
+### 1. Note Calibre affichée uniquement si lu
+
+Avant : `calibreRating` ("4/10") s'affichait pour tous les livres possédés dans Calibre, qu'ils soient lus ou non. Cela créait de la confusion car le "4/10" semble être une note Masque.
+
+Après : la note Calibre n'est affichée que si `calibreLu = true`. Si non lu, seul le symbole ◯ apparaît.
+
+```kotlin
+if (item.calibreLu) {
+    item.calibreRating?.let {
+        Text(text = "${it.toInt()}/10", ...)
+    }
+}
+```
+
+### 2. Ordre des colonnes inversé
+
+Avant : `#rank | titre/auteur | NoteBadge+nbAvis | ✓/◯+calibreRating`
+Après : `#rank | titre/auteur | ✓/◯+calibreRating | NoteBadge+nbAvis`
+
+Le badge de note Masque est maintenant à **l'extrême droite**, conformément à la demande (issue #27).
+
+## Fichier modifié
+
+- `app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt` — composable `PalmaresCard`
+
+## Points clés
+
+- Pas de modification de modèle ou DAO — purement UI
+- `calibreRating` reste dans `PalmaresUi` et `PalmaresEntity` (données toujours disponibles si besoin futur)
+- Pas de nouveaux tests unitaires nécessaires (logique d'affichage pure)


### PR DESCRIPTION
## Summary

- La note Calibre (X/10) n'est désormais affichée que si le livre est **lu** dans Calibre (`calibreLu=true`) — elle était auparavant visible pour tous les livres possédés, créant de la confusion
- Ordre des colonnes inversé : la colonne possession (✓/◯) passe avant le badge de note Masque, qui est maintenant à l'**extrême droite** de la carte

## Test plan

- [ ] Vérifier qu'un livre non lu (◯) n'affiche plus de note X/10
- [ ] Vérifier qu'un livre lu (✓) affiche toujours sa note Calibre sous le ✓
- [ ] Vérifier que le badge de note Masque est bien à droite de ✓/◯

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)