### PR TITLE
fix: renumérotation consécutive des Conseils après filtrage (issue #28)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/ui/recommendations/RecommendationsScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/recommendations/RecommendationsScreen.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
@@ -74,15 +74,15 @@ fun RecommendationsContent(
         uiState.error != null -> ErrorMessage(uiState.error, modifier)
         uiState.recommendations.isEmpty() -> EmptyState("Aucun conseil disponible", modifier)
         else -> LazyColumn(modifier = modifier) {
-            items(uiState.recommendations, key = { it.livreId }) { item ->
-                RecommendationCard(item = item, onClick = { onLivreClick(item.livreId) })
+            itemsIndexed(uiState.recommendations, key = { _, item -> item.livreId }) { index, item ->
+                RecommendationCard(item = item, displayRank = index + 1, onClick = { onLivreClick(item.livreId) })
             }
         }
     }
 }
 
 @Composable
-fun RecommendationCard(item: RecommendationUi, onClick: () -> Unit) {
+fun RecommendationCard(item: RecommendationUi, displayRank: Int, onClick: () -> Unit) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -94,7 +94,7 @@ fun RecommendationCard(item: RecommendationUi, onClick: () -> Unit) {
             horizontalArrangement = Arrangement.spacedBy(12.dp)
         ) {
             Text(
-                text = "#${item.rank}",
+                text = "#$displayRank",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.primary
             )

--- a/docs/claude/memory/260309-1530-issue28-conseils-renumerotation.md
+++ b/docs/claude/memory/260309-1530-issue28-conseils-renumerotation.md
@@ -1,0 +1,28 @@
+# Issue #28 — Renumérotation des Conseils
+
+Date : 2026-03-09
+Branche : `28-conseils-renommer-les-pour-quils-se-suivent`
+
+## Problème
+
+Après le filtrage des livres lus (issue #19), l'écran Conseils affichait les rangs stockés en base (`rank` de la table `recommendations`), qui ne se suivent plus après filtrage (ex: #2, #5, #7…).
+
+## Solution
+
+Dans `app/src/main/java/com/lmelp/mobile/ui/recommendations/RecommendationsScreen.kt` :
+
+- Remplacement de `items(...)` par `itemsIndexed(...)` dans `RecommendationsContent`
+- `RecommendationCard` reçoit un nouveau paramètre `displayRank: Int` (au lieu d'utiliser `item.rank`)
+- Affichage `"#$displayRank"` = `index + 1` → numérotation 1, 2, 3... consécutive
+
+```kotlin
+itemsIndexed(uiState.recommendations, key = { _, item -> item.livreId }) { index, item ->
+    RecommendationCard(item = item, displayRank = index + 1, onClick = { ... })
+}
+```
+
+## Points clés
+
+- Le champ `rank` de `RecommendationUi` reste inchangé (rank SVD de la base, utile pour le tri)
+- La numérotation affichée est découplée du rang de base → robuste à tout filtrage futur
+- Correction purement UI, aucun changement de modèle ou DAO


### PR DESCRIPTION
## Summary

- Les rangs affichés dans l'écran Conseils ne se suivaient plus après filtrage des livres lus (reliquat de #19)
- `items()` remplacé par `itemsIndexed()` + paramètre `displayRank = index + 1`
- La numérotation est maintenant 1, 2, 3... indépendamment du rang SVD stocké en base

## Test plan

- [ ] Vérifier que les Conseils commencent bien à #1
- [ ] Vérifier que la numérotation est consécutive sans trou

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)