### PR TITLE
chore: mise à jour Android Gradle Plugin 8.5.2 → 8.7.3 (issue #10)

### DIFF
--- a/docs/claude/memory/260310-0900-issue10-agp-update.md
+++ b/docs/claude/memory/260310-0900-issue10-agp-update.md
@@ -1,0 +1,22 @@
+# Issue #10 — Mise à jour Android Gradle Plugin (8.5.2 → 8.7.3)
+
+Date : 2026-03-10
+Branche : `10-tech-agp-update`
+
+## Changements
+
+- `gradle/libs.versions.toml` : `agp = "8.5.2"` → `"8.7.3"`
+- `gradle.properties` : suppression de `android.suppressUnsupportedCompileSdk=35` (workaround devenu inutile)
+
+## Compatibilité vérifiée
+
+| Composant | Version | Compatible AGP 8.7.x |
+|-----------|---------|----------------------|
+| Gradle wrapper | 8.9 | ✅ |
+| Kotlin | 2.0.21 | ✅ |
+| KSP | 2.0.21-1.0.27 | ✅ |
+| compileSdk | 35 | ✅ (supporté nativement) |
+
+## Résultat
+
+Build sans aucun warning AGP. `android.suppressUnsupportedCompileSdk=35` supprimé proprement.

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,3 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 android.useAndroidX=true
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.suppressUnsupportedCompileSdk=35

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.5.2"
+agp = "8.7.3"
 kotlin = "2.0.21"
 ksp = "2.0.21-1.0.27"
 coreKtx = "1.13.1"


### PR DESCRIPTION
## Summary

- `agp` mis à jour de `8.5.2` vers `8.7.3` dans `gradle/libs.versions.toml`
- Suppression du workaround `android.suppressUnsupportedCompileSdk=35` dans `gradle.properties` (inutile avec AGP 8.7.3 qui supporte compileSdk 35 nativement)
- Gradle wrapper 8.9 + Kotlin 2.0.21 déjà compatibles → aucun autre changement nécessaire

## Test plan

- [ ] `./gradlew assembleDebug` — pas de warning AGP
- [ ] `./gradlew testDebugUnitTest` — tous les tests passent
- [ ] `./gradlew lintDebug` — pas d'erreur lint

🤖 Generated with [Claude Code](https://claude.com/claude-code)