### PR TITLE
feat: masquer les labels de navigation en mode paysage (issue #14)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/MainActivity.kt
+++ b/app/src/main/java/com/lmelp/mobile/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.lmelp.mobile
 
+import android.content.res.Configuration
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -25,6 +26,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -50,6 +52,7 @@ class MainActivity : ComponentActivity() {
                 val navBackStack by navController.currentBackStackEntryAsState()
                 val currentRoute = navBackStack?.destination?.route
                 var swipeDirection by remember { mutableStateOf(0) }
+                val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
 
                 val bottomNavItems = listOf(
                     BottomNavItem("Accueil", Routes.HOME, Icons.Default.Home),
@@ -114,7 +117,9 @@ class MainActivity : ComponentActivity() {
                                             }
                                         },
                                         icon = { Icon(item.icon, contentDescription = item.label) },
-                                        label = { Text(item.label) }
+                                        label = if (shouldShowLabel(isLandscape)) {
+                                            { Text(item.label) }
+                                        } else null
                                     )
                                 }
                             }

--- a/app/src/main/java/com/lmelp/mobile/NavigationUtils.kt
+++ b/app/src/main/java/com/lmelp/mobile/NavigationUtils.kt
@@ -1,0 +1,7 @@
+package com.lmelp.mobile
+
+/**
+ * Retourne true si les labels de la barre de navigation doivent être affichés.
+ * En mode paysage, on masque les labels pour éviter qu'ils soient coupés (issue #14).
+ */
+fun shouldShowLabel(isLandscape: Boolean): Boolean = !isLandscape

--- a/app/src/test/java/com/lmelp/mobile/NavigationLabelTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/NavigationLabelTest.kt
@@ -1,0 +1,29 @@
+package com.lmelp.mobile
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Tests pour shouldShowLabel — masque les labels de la barre de navigation en mode paysage.
+ *
+ * Comportement attendu (issue #14) :
+ *   portrait  (isLandscape = false) → afficher les labels (true)
+ *   paysage   (isLandscape = true)  → masquer les labels (false)
+ */
+class NavigationLabelTest {
+
+    // --- Mode portrait ---
+
+    @Test
+    fun `en portrait les labels sont affichés`() {
+        assertTrue(shouldShowLabel(isLandscape = false))
+    }
+
+    // --- Mode paysage ---
+
+    @Test
+    fun `en paysage les labels sont masqués`() {
+        assertFalse(shouldShowLabel(isLandscape = true))
+    }
+}

--- a/docs/claude/memory/260310-1050-issue14-landscape-navigation-labels.md
+++ b/docs/claude/memory/260310-1050-issue14-landscape-navigation-labels.md
@@ -1,0 +1,40 @@
+# Issue #14 — Masquer les labels en mode paysage (barre de navigation)
+
+## Problème
+En mode paysage (landscape), les labels des onglets de la `NavigationBar` ("Émissions", "Palmarès", "Conseils", "Recherche") étaient coupés faute de place verticale.
+
+## Solution
+Masquer les labels (afficher uniquement les icônes) en mode paysage.
+
+## Fichiers créés/modifiés
+- `app/src/main/java/com/lmelp/mobile/NavigationUtils.kt` — fonction pure `shouldShowLabel(isLandscape: Boolean): Boolean`
+- `app/src/main/java/com/lmelp/mobile/MainActivity.kt` — détection orientation + label conditionnel
+- `app/src/test/java/com/lmelp/mobile/NavigationLabelTest.kt` — tests TDD (2 tests)
+
+## Détails d'implémentation
+
+### NavigationUtils.kt
+```kotlin
+fun shouldShowLabel(isLandscape: Boolean): Boolean = !isLandscape
+```
+
+### MainActivity.kt — détection orientation
+```kotlin
+import android.content.res.Configuration
+import androidx.compose.ui.platform.LocalConfiguration
+
+val isLandscape = LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+```
+
+### MainActivity.kt — label conditionnel dans NavigationBarItem
+```kotlin
+label = if (shouldShowLabel(isLandscape)) { { Text(item.label) } } else null
+```
+
+## Pattern TDD appliqué
+1. Test RED écrit en premier → compilation échoue (fonction inexistante)
+2. Implémentation de `shouldShowLabel` → tests passent (GREEN)
+3. Lint + build debug → OK
+
+## Pattern de test (JUnit 4 pur, sans Android runner)
+Identique à `NoteColorTest.kt` — tests sur logique pure sans dépendance Compose/Android.


### PR DESCRIPTION
## Summary

- En mode paysage, les labels des onglets de la barre de navigation étaient coupés
- On masque désormais les labels (`label = null`) et n'affiche que les icônes lorsque `isLandscape = true`
- Nouvelle fonction utilitaire pure `shouldShowLabel(isLandscape: Boolean)` dans `NavigationUtils.kt`

## Test plan

- [ ] Tester en mode portrait : les labels (Émissions, Palmarès, Conseils, Recherche) sont visibles
- [ ] Tester en mode paysage : seules les icônes sont affichées, aucun texte coupé
- [ ] `./gradlew testDebugUnitTest` → tous les tests passent (dont `NavigationLabelTest`)
- [ ] `./gradlew lintDebug` → aucune erreur
- [ ] `./gradlew assembleDebug` → build OK

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)