### PR TITLE
fix: cacher le clavier après validation de la recherche (issue #44)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt
@@ -24,6 +24,7 @@ import com.lmelp.mobile.ui.theme.LmelpVert
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -71,11 +72,12 @@ fun SearchContent(
     onResultClick: (type: String, id: String) -> Unit,
     modifier: Modifier = Modifier
 ) {
+    val keyboardController = LocalSoftwareKeyboardController.current
     Column(modifier = modifier) {
         SearchBar(
             query = uiState.query,
             onQueryChange = onQueryChange,
-            onSearch = {},
+            onSearch = { keyboardController?.hide() },
             active = false,
             onActiveChange = {},
             placeholder = { Text("Rechercher un livre, auteur, critique...") },

--- a/docs/claude/memory/260311-1300-issue44-recherche-cacher-clavier.md
+++ b/docs/claude/memory/260311-1300-issue44-recherche-cacher-clavier.md
@@ -1,0 +1,35 @@
+# Issue #44 — Recherche : cacher le clavier au lancement de la recherche
+
+## Problème
+
+Quand l'utilisateur tape une requête dans la SearchBar et valide avec la touche "Rechercher" du clavier Android, le clavier restait affiché et masquait les résultats de recherche.
+
+## Cause
+
+Dans `app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt`, le callback `onSearch` de la `SearchBar` était vide (`onSearch = {}`), donc aucune action n'était déclenchée lors de la validation.
+
+## Fix
+
+Utilisation de `LocalSoftwareKeyboardController` (API Compose standard) pour cacher le clavier dans `onSearch`.
+
+**Fichier modifié** : `app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt`
+
+Ajout de l'import :
+```kotlin
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
+```
+
+Dans `SearchContent` :
+```kotlin
+val keyboardController = LocalSoftwareKeyboardController.current
+// ...
+onSearch = { keyboardController?.hide() },
+```
+
+## Pattern retenu
+
+`LocalSoftwareKeyboardController.current` est la méthode recommandée dans Jetpack Compose pour cacher le clavier programmatiquement. Elle doit être appelée au niveau Composable (pas dans un lambda), puis utilisée dans les callbacks.
+
+## Tests
+
+Changement purement UI — pas de logique ViewModel testable unitairement. Vérification par build (`./gradlew assembleDebug`) et test manuel.


### PR DESCRIPTION
## Summary

- Dans `SearchContent`, le callback `onSearch` de la `SearchBar` était vide (`{}`), ce qui laissait le clavier affiché et masquait les résultats après validation
- Ajout de `LocalSoftwareKeyboardController` pour appeler `keyboardController?.hide()` dans `onSearch`

## Changement

`app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt` — 3 lignes ajoutées

## Test plan

- [ ] Lancer l'app, aller sur l'onglet Recherche
- [ ] Taper une requête (ex: "hamlet")
- [ ] Appuyer sur la touche "Rechercher" (loupe) du clavier virtuel
- [ ] Vérifier que le clavier se ferme et que les résultats sont visibles

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)