### PR TITLE
feat: améliorer la fiche livre — note moyenne, avis groupés par émission (issue #45)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/Navigation.kt
+++ b/app/src/main/java/com/lmelp/mobile/Navigation.kt
@@ -94,7 +94,8 @@ fun LmelpNavHost(
             LivreDetailScreen(
                 livreId = livreId,
                 repository = app.livresRepository,
-                onBack = { navController.popBackStack() }
+                onBack = { navController.popBackStack() },
+                onEmissionClick = { navController.navigate(Routes.emissionDetail(it)) }
             )
         }
 

--- a/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
@@ -2,6 +2,7 @@ package com.lmelp.mobile.data.db
 
 import androidx.room.ColumnInfo
 import androidx.room.Dao
+import androidx.room.Embedded
 import androidx.room.Query
 import com.lmelp.mobile.data.model.AvisEntity
 import com.lmelp.mobile.data.model.LivreEntity
@@ -11,6 +12,13 @@ data class LivreNoteSection(
     @ColumnInfo(name = "livre_id") val livreId: String,
     @ColumnInfo(name = "avg_note") val avgNote: Double?,
     val section: String?
+)
+
+/** Avis enrichi avec le titre et la date de l'émission associée. */
+data class AvisAvecEmissionRow(
+    @Embedded val avis: AvisEntity,
+    @ColumnInfo(name = "emission_titre") val emissionTitre: String?,
+    @ColumnInfo(name = "emission_date") val emissionDate: String?
 )
 
 @Dao
@@ -31,4 +39,13 @@ interface LivresDao {
 
     @Query("SELECT livre_id, AVG(note) as avg_note, section FROM avis WHERE emission_id = :emissionId GROUP BY livre_id")
     suspend fun getNotesParLivreForEmission(emissionId: String): List<LivreNoteSection>
+
+    @Query("""
+        SELECT a.*, ep.titre as emission_titre, em.date as emission_date
+        FROM avis a
+        JOIN emissions em ON em.id = a.emission_id
+        JOIN episodes ep ON ep.id = em.episode_id
+        WHERE a.livre_id = :livreId
+    """)
+    suspend fun getAvisAvecEmissionByLivre(livreId: String): List<AvisAvecEmissionRow>
 }

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -29,21 +29,29 @@ data class LivreUi(
     val section: String? = null
 )
 
-data class LivreDetailUi(
-    val id: String,
-    val titre: String,
-    val auteurNom: String?,
-    val editeur: String?,
-    val urlBabelio: String?,
-    val avis: List<AvisUi>
-)
-
 data class AvisUi(
     val id: String,
     val critiqueNom: String?,
     val note: Double?,
     val commentaire: String?,
     val emissionId: String
+)
+
+data class AvisParEmissionUi(
+    val emissionId: String,
+    val emissionTitre: String?,
+    val emissionDate: String?,
+    val avis: List<AvisUi>
+)
+
+data class LivreDetailUi(
+    val id: String,
+    val titre: String,
+    val auteurNom: String?,
+    val editeur: String?,
+    val urlBabelio: String?,
+    val noteMoyenne: Double?,
+    val avisParEmission: List<AvisParEmissionUi>
 )
 
 data class PalmaresUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
@@ -1,6 +1,7 @@
 package com.lmelp.mobile.data.repository
 
 import com.lmelp.mobile.data.db.LivresDao
+import com.lmelp.mobile.data.model.AvisParEmissionUi
 import com.lmelp.mobile.data.model.AvisUi
 import com.lmelp.mobile.data.model.LivreDetailUi
 
@@ -10,22 +11,45 @@ class LivresRepository(
 
     suspend fun getLivreDetail(livreId: String): LivreDetailUi? {
         val livre = livresDao.getLivreById(livreId) ?: return null
-        val avis = livresDao.getAvisByLivre(livreId).map {
-            AvisUi(
-                id = it.id,
-                critiqueNom = it.critiqueNom,
-                note = it.note,
-                commentaire = it.commentaire,
-                emissionId = it.emissionId
-            )
-        }
+        val rows = livresDao.getAvisAvecEmissionByLivre(livreId)
+
+        val noteMoyenne = rows.mapNotNull { it.avis.note }
+            .takeIf { it.isNotEmpty() }
+            ?.average()
+
+        // Grouper par émission en conservant l'ordre (date DESC)
+        val avisParEmission = rows
+            .groupBy { it.avis.emissionId }
+            .entries
+            .sortedByDescending { (_, groupRows) -> groupRows.first().emissionDate }
+            .map { (emissionId, groupRows) ->
+                val first = groupRows.first()
+                AvisParEmissionUi(
+                    emissionId = emissionId,
+                    emissionTitre = first.emissionTitre,
+                    emissionDate = first.emissionDate,
+                    avis = groupRows
+                        .sortedBy { it.avis.critiqueNom ?: "" }
+                        .map { row ->
+                            AvisUi(
+                                id = row.avis.id,
+                                critiqueNom = row.avis.critiqueNom,
+                                note = row.avis.note,
+                                commentaire = row.avis.commentaire,
+                                emissionId = row.avis.emissionId
+                            )
+                        }
+                )
+            }
+
         return LivreDetailUi(
             id = livre.id,
             titre = livre.titre,
             auteurNom = livre.auteurNom,
             editeur = livre.editeur,
             urlBabelio = livre.urlBabelio,
-            avis = avis
+            noteMoyenne = noteMoyenne,
+            avisParEmission = avisParEmission
         )
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/components/CommonComponents.kt
@@ -12,6 +12,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.lmelp.mobile.ui.theme.couleurNote
@@ -56,9 +58,14 @@ fun EmptyState(message: String, modifier: Modifier = Modifier) {
  * @param suffix  Suffixe optionnel affiché après la note (ex: "/10")
  */
 @Composable
-fun NoteBadge(note: Double, suffix: String = "") {
+fun NoteBadge(
+    note: Double,
+    suffix: String = "",
+    fontSize: TextUnit = 14.sp,
+    modifier: Modifier = Modifier
+) {
     Box(
-        modifier = Modifier
+        modifier = modifier
             .clip(RoundedCornerShape(4.dp))
             .background(couleurNote(note))
             .padding(horizontal = 6.dp, vertical = 2.dp)
@@ -67,7 +74,7 @@ fun NoteBadge(note: Double, suffix: String = "") {
             text = "${formatNote(note)}$suffix",
             color = couleurTexteNote(note),
             fontWeight = FontWeight.Bold,
-            fontSize = 14.sp
+            fontSize = fontSize
         )
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
@@ -1,5 +1,7 @@
 package com.lmelp.mobile.ui.emissions
 
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -19,10 +21,14 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lmelp.mobile.data.model.AvisParEmissionUi
 import com.lmelp.mobile.data.model.AvisUi
 import com.lmelp.mobile.data.model.LivreDetailUi
 import com.lmelp.mobile.data.repository.LivresRepository
@@ -37,7 +43,8 @@ import com.lmelp.mobile.viewmodel.LivreDetailViewModel
 fun LivreDetailScreen(
     livreId: String,
     repository: LivresRepository,
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    onEmissionClick: (String) -> Unit = {}
 ) {
     val viewModel: LivreDetailViewModel = viewModel(
         factory = LivreDetailViewModel.Factory(repository, livreId)
@@ -61,6 +68,7 @@ fun LivreDetailScreen(
             uiState.error != null -> ErrorMessage(uiState.error!!, Modifier.padding(padding))
             uiState.livre != null -> LivreDetailContent(
                 livre = uiState.livre!!,
+                onEmissionClick = onEmissionClick,
                 modifier = Modifier.padding(padding)
             )
             else -> EmptyState("Livre introuvable", Modifier.padding(padding))
@@ -69,24 +77,76 @@ fun LivreDetailScreen(
 }
 
 @Composable
-fun LivreDetailContent(livre: LivreDetailUi, modifier: Modifier = Modifier) {
+fun LivreDetailContent(
+    livre: LivreDetailUi,
+    onEmissionClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
     LazyColumn(modifier = modifier) {
         item {
-            Column(modifier = Modifier.padding(16.dp)) {
-                livre.auteurNom?.let {
-                    Text(it, style = MaterialTheme.typography.bodyLarge)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.Top
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    livre.auteurNom?.let {
+                        Text(it, style = MaterialTheme.typography.bodyLarge)
+                    }
+                    livre.editeur?.let {
+                        Text(
+                            it,
+                            style = MaterialTheme.typography.bodyMedium,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
                 }
-                livre.editeur?.let {
-                    Text(it, style = MaterialTheme.typography.bodyMedium, modifier = Modifier.padding(top = 4.dp))
-                }
-                if (livre.avis.isNotEmpty()) {
-                    HorizontalDivider(modifier = Modifier.padding(vertical = 12.dp))
-                    Text("Avis des critiques", style = MaterialTheme.typography.titleMedium)
+                livre.noteMoyenne?.let {
+                    NoteBadge(note = it, fontSize = 32.sp, modifier = Modifier.padding(start = 8.dp))
                 }
             }
         }
-        items(livre.avis, key = { it.id }) { avis ->
-            AvisCard(avis = avis)
+        if (livre.avisParEmission.isNotEmpty()) {
+            item {
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
+            }
+        }
+        livre.avisParEmission.forEach { groupe ->
+            item(key = "header_${groupe.emissionId}") {
+                EmissionGroupHeader(
+                    groupe = groupe,
+                    onClick = { onEmissionClick(groupe.emissionId) }
+                )
+            }
+            items(groupe.avis, key = { it.id }) { avis ->
+                AvisCard(avis = avis)
+            }
+        }
+    }
+}
+
+@Composable
+fun EmissionGroupHeader(groupe: AvisParEmissionUi, onClick: () -> Unit) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+    ) {
+        Text(
+            text = groupe.emissionTitre ?: groupe.emissionId,
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            color = MaterialTheme.colorScheme.primary
+        )
+        groupe.emissionDate?.let {
+            Text(
+                text = formatDateLong(it),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
         }
     }
 }

--- a/app/src/test/java/com/lmelp/mobile/LivresRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/LivresRepositoryTest.kt
@@ -1,0 +1,127 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.AvisAvecEmissionRow
+import com.lmelp.mobile.data.db.LivresDao
+import com.lmelp.mobile.data.model.AvisEntity
+import com.lmelp.mobile.data.model.LivreEntity
+import com.lmelp.mobile.data.repository.LivresRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class LivresRepositoryTest {
+
+    private fun makeAvisEntity(
+        id: String,
+        emissionId: String,
+        livreId: String,
+        critiqueNom: String?,
+        note: Double?
+    ) = AvisEntity(
+        id = id,
+        emissionId = emissionId,
+        livreId = livreId,
+        critiqueId = "c1",
+        note = note,
+        commentaire = null,
+        livreTitre = null,
+        auteurNom = null,
+        critiqueNom = critiqueNom,
+        matchPhase = null,
+        section = null,
+        createdAt = null
+    )
+
+    private fun makeLivreEntity(id: String) = LivreEntity(
+        id = id,
+        titre = "Titre $id",
+        auteurId = null,
+        auteurNom = "Auteur",
+        editeur = null,
+        urlBabelio = null,
+        createdAt = null,
+        updatedAt = null
+    )
+
+    @Test
+    fun `noteMoyenne calculee comme moyenne des notes non nulles`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
+            listOf(
+                AvisAvecEmissionRow(makeAvisEntity("a1", "e1", "l1", "Zola", 8.0), "Emission 1", "2023-01-10"),
+                AvisAvecEmissionRow(makeAvisEntity("a2", "e1", "l1", "Arnaud", 6.0), "Emission 1", "2023-01-10"),
+                AvisAvecEmissionRow(makeAvisEntity("a3", "e1", "l1", "Berenice", null), "Emission 1", "2023-01-10"),
+            )
+        )
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")
+
+        // noteMoyenne = (8.0 + 6.0) / 2 = 7.0 (note nulle ignorée)
+        assertEquals(7.0, result!!.noteMoyenne!!, 0.001)
+    }
+
+    @Test
+    fun `noteMoyenne est null si aucun avis na de note`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
+            listOf(
+                AvisAvecEmissionRow(makeAvisEntity("a1", "e1", "l1", "Zola", null), "Emission 1", "2023-01-10"),
+            )
+        )
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")
+
+        assertNull(result!!.noteMoyenne)
+    }
+
+    @Test
+    fun `avis regroupes par emission dans l ordre chronologique inverse`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        // e2 est plus récente (2024), e1 est plus ancienne (2023)
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
+            listOf(
+                AvisAvecEmissionRow(makeAvisEntity("a1", "e1", "l1", "Arnaud", 7.0), "Ancienne Emission", "2023-03-01"),
+                AvisAvecEmissionRow(makeAvisEntity("a2", "e2", "l1", "Zola", 9.0), "Recente Emission", "2024-06-15"),
+            )
+        )
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")!!
+
+        assertEquals(2, result.avisParEmission.size)
+        // La plus récente (e2) doit apparaître en premier
+        assertEquals("e2", result.avisParEmission[0].emissionId)
+        assertEquals("e1", result.avisParEmission[1].emissionId)
+    }
+
+    @Test
+    fun `avis tries par critique alphabetique dans chaque groupe`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
+            listOf(
+                AvisAvecEmissionRow(makeAvisEntity("a1", "e1", "l1", "Zola", 8.0), "Emission 1", "2023-01-10"),
+                AvisAvecEmissionRow(makeAvisEntity("a2", "e1", "l1", "Arnaud", 6.0), "Emission 1", "2023-01-10"),
+                AvisAvecEmissionRow(makeAvisEntity("a3", "e1", "l1", "Berenice", 7.0), "Emission 1", "2023-01-10"),
+            )
+        )
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")!!
+
+        val avis = result.avisParEmission[0].avis
+        assertEquals(3, avis.size)
+        assertEquals("Arnaud", avis[0].critiqueNom)
+        assertEquals("Berenice", avis[1].critiqueNom)
+        assertEquals("Zola", avis[2].critiqueNom)
+    }
+}

--- a/docs/claude/memory/260311-2200-issue45-fiche-livre-amelioration-affichage.md
+++ b/docs/claude/memory/260311-2200-issue45-fiche-livre-amelioration-affichage.md
@@ -1,0 +1,84 @@
+# Issue #45 — Fiche livre : amélioration de l'affichage
+
+## Problème
+
+La fiche livre affichait les avis de façon plate (liste sans regroupement). L'issue demandait :
+
+1. Note moyenne en haut à droite en gros (badge 32sp avec la bonne couleur)
+2. Avis regroupés par émission, précédés du titre de l'émission
+3. En-têtes d'émission cliquables → navigation vers l'émission
+4. Avis triés par ordre alphabétique de critique au sein de chaque groupe d'émission
+
+## Architecture de la solution
+
+### Nouveau DAO avec jointure SQL
+
+`app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt`
+
+Ajout de `AvisAvecEmissionRow` (`@Embedded` + deux colonnes supplémentaires) et d'une query avec double jointure `avis → emissions → episodes` pour récupérer titre et date de l'émission :
+
+```sql
+SELECT a.*, ep.titre as emission_titre, em.date as emission_date
+FROM avis a
+JOIN emissions em ON em.id = a.emission_id
+JOIN episodes ep ON ep.id = em.episode_id
+WHERE a.livre_id = :livreId
+```
+
+Le titre d'une émission = titre de l'épisode associé (table `episodes`).
+
+### Nouveaux modèles UI
+
+`app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt`
+
+- `AvisParEmissionUi` : nouveau data class (emissionId, emissionTitre, emissionDate, avis: List<AvisUi>)
+- `LivreDetailUi` : remplace `avis: List<AvisUi>` par `avisParEmission: List<AvisParEmissionUi>` + ajout de `noteMoyenne: Double?`
+
+### Logique de groupement dans le Repository
+
+`app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt`
+
+- `noteMoyenne` = moyenne des notes non nulles
+- Groupement par `emissionId` avec `groupBy` puis `sortedByDescending(emissionDate)`
+- Dans chaque groupe : `sortedBy { it.avis.critiqueNom ?: "" }`
+
+### UI mise à jour
+
+`app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt`
+
+- Header avec `Row` : auteur/éditeur à gauche, `NoteBadge(fontSize = 32.sp)` à droite
+- Nouveau composable `EmissionGroupHeader` : titre cliquable + date formatée
+- La `LazyColumn` itère sur `livre.avisParEmission` avec `forEach` pour les headers et `items()` pour les avis
+
+### NoteBadge enrichi
+
+`app/src/main/java/com/lmelp/mobile/ui/components/CommonComponents.kt`
+
+Ajout du paramètre `fontSize: TextUnit = 14.sp` à `NoteBadge` pour permettre le badge grande taille (32sp) sans briser les usages existants.
+
+### Navigation
+
+`app/src/main/java/com/lmelp/mobile/Navigation.kt`
+
+Ajout de `onEmissionClick = { navController.navigate(Routes.emissionDetail(it)) }` dans le composable `LIVRE_DETAIL`.
+
+## Tests TDD
+
+`app/src/test/java/com/lmelp/mobile/LivresRepositoryTest.kt`
+
+4 tests unitaires couvrant :
+- `noteMoyenne` calculée correctement (notes nulles ignorées)
+- `noteMoyenne` null si aucun avis n'a de note
+- Groupes d'émissions triés par date DESC (plus récent en premier)
+- Avis triés alphabétiquement par critique au sein d'un groupe
+
+## Pattern Room `@Embedded` + colonnes supplémentaires
+
+Pour une query Room qui retourne une entité + des colonnes supplémentaires, utiliser :
+```kotlin
+data class MyRow(
+    @Embedded val entity: MyEntity,
+    @ColumnInfo(name = "extra_col") val extraCol: String?
+)
+```
+Aucun conflit de noms si les colonnes supplémentaires ont des alias SQL distincts des colonnes de l'entité.


### PR DESCRIPTION
## Summary

- Badge 32sp avec la note moyenne en haut à droite de la fiche livre
- Avis regroupés par émission (ordre chronologique inverse), avec titre de l'émission en en-tête
- En-têtes d'émission cliquables → navigation vers l'émission concernée
- Avis triés alphabétiquement par critique dans chaque groupe

## Changements

- `LivresDao` : nouvelle query avec jointure `avis → emissions → episodes` + data class `AvisAvecEmissionRow`
- `UiModels` : nouveau `AvisParEmissionUi`, `LivreDetailUi` enrichi (`noteMoyenne`, `avisParEmission`)
- `LivresRepository` : groupement, tri, calcul note moyenne
- `LivreDetailScreen` : header avec badge 32sp, `EmissionGroupHeader` cliquable
- `CommonComponents` : `NoteBadge` avec param `fontSize` optionnel
- `Navigation` : `onEmissionClick` passé à `LivreDetailScreen`
- 4 tests unitaires dans `LivresRepositoryTest`

## Test plan

- [ ] Ouvrir la fiche d'un livre (depuis Palmarès, Recherche ou Émission)
- [ ] Vérifier la note moyenne en grand badge coloré en haut à droite
- [ ] Vérifier les avis groupés par émission (plus récente en premier)
- [ ] Vérifier le tri alphabétique des critiques dans chaque groupe
- [ ] Cliquer sur un titre d'émission → navigation vers l'émission

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)