### PR TITLE
feat: créer la fiche auteur accessible depuis un livre ou la recherche (issue #47)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/LmelpApp.kt
+++ b/app/src/main/java/com/lmelp/mobile/LmelpApp.kt
@@ -2,6 +2,7 @@ package com.lmelp.mobile
 
 import android.app.Application
 import com.lmelp.mobile.data.db.LmelpDatabase
+import com.lmelp.mobile.data.repository.AuteursRepository
 import com.lmelp.mobile.data.repository.CritiquesRepository
 import com.lmelp.mobile.data.repository.EmissionsRepository
 import com.lmelp.mobile.data.repository.LivresRepository
@@ -28,4 +29,5 @@ class LmelpApp : Application() {
     val recommendationsRepository by lazy { RecommendationsRepository(database.recommendationsDao()) }
     val searchRepository by lazy { SearchRepository(database.searchDao()) }
     val metadataRepository by lazy { MetadataRepository(database.metadataDao()) }
+    val auteursRepository by lazy { AuteursRepository(database.auteursDao()) }
 }

--- a/app/src/main/java/com/lmelp/mobile/Navigation.kt
+++ b/app/src/main/java/com/lmelp/mobile/Navigation.kt
@@ -10,6 +10,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.lmelp.mobile.ui.about.AboutScreen
+import com.lmelp.mobile.ui.auteurs.AuteurDetailScreen
 import com.lmelp.mobile.ui.critiques.CritiquesScreen
 import com.lmelp.mobile.ui.emissions.EmissionDetailScreen
 import com.lmelp.mobile.ui.emissions.EmissionsScreen
@@ -25,6 +26,7 @@ object Routes {
     const val EMISSIONS = "emissions"
     const val EMISSION_DETAIL = "emission/{emissionId}"
     const val LIVRE_DETAIL = "livre/{livreId}"
+    const val AUTEUR_DETAIL = "auteur/{auteurId}"
     const val PALMARES = "palmares"
     const val CRITIQUES = "critiques"
     const val SEARCH = "search"
@@ -32,6 +34,7 @@ object Routes {
 
     fun emissionDetail(emissionId: String) = "emission/$emissionId"
     fun livreDetail(livreId: String) = "livre/$livreId"
+    fun auteurDetail(auteurId: String) = "auteur/$auteurId"
 }
 
 @Composable
@@ -95,7 +98,21 @@ fun LmelpNavHost(
                 livreId = livreId,
                 repository = app.livresRepository,
                 onBack = { navController.popBackStack() },
-                onEmissionClick = { navController.navigate(Routes.emissionDetail(it)) }
+                onEmissionClick = { navController.navigate(Routes.emissionDetail(it)) },
+                onAuteurClick = { navController.navigate(Routes.auteurDetail(it)) }
+            )
+        }
+
+        composable(
+            route = Routes.AUTEUR_DETAIL,
+            arguments = listOf(navArgument("auteurId") { type = NavType.StringType })
+        ) { backStack ->
+            val auteurId = backStack.arguments?.getString("auteurId") ?: return@composable
+            AuteurDetailScreen(
+                auteurId = auteurId,
+                repository = app.auteursRepository,
+                onBack = { navController.popBackStack() },
+                onLivreClick = { navController.navigate(Routes.livreDetail(it)) }
             )
         }
 
@@ -125,6 +142,7 @@ fun LmelpNavHost(
                     when (type) {
                         "livre" -> navController.navigate(Routes.livreDetail(id))
                         "emission" -> navController.navigate(Routes.emissionDetail(id))
+                        "auteur" -> navController.navigate(Routes.auteurDetail(id))
                         else -> {}
                     }
                 }

--- a/app/src/main/java/com/lmelp/mobile/data/db/AuteursDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/AuteursDao.kt
@@ -1,0 +1,34 @@
+package com.lmelp.mobile.data.db
+
+import androidx.room.ColumnInfo
+import androidx.room.Dao
+import androidx.room.Query
+import com.lmelp.mobile.data.model.AuteurEntity
+
+/** Livre d'un auteur avec note moyenne (depuis palmares) et date de dernière émission. */
+data class LivreParAuteurRow(
+    @ColumnInfo(name = "livre_id") val livreId: String,
+    val titre: String,
+    @ColumnInfo(name = "note_moyenne") val noteMoyenne: Double?,
+    @ColumnInfo(name = "derniere_emission_date") val derniereEmissionDate: String?
+)
+
+@Dao
+interface AuteursDao {
+
+    @Query("SELECT * FROM auteurs WHERE id = :id")
+    suspend fun getAuteurById(id: String): AuteurEntity?
+
+    @Query("""
+        SELECT l.id as livre_id, l.titre,
+               p.note_moyenne,
+               MAX(em.date) as derniere_emission_date
+        FROM livres l
+        LEFT JOIN palmares p ON p.livre_id = l.id
+        LEFT JOIN avis a ON a.livre_id = l.id
+        LEFT JOIN emissions em ON em.id = a.emission_id
+        WHERE l.auteur_id = :auteurId
+        GROUP BY l.id
+    """)
+    suspend fun getLivresParAuteur(auteurId: String): List<LivreParAuteurRow>
+}

--- a/app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt
@@ -45,6 +45,7 @@ abstract class LmelpDatabase : RoomDatabase() {
     abstract fun searchDao(): SearchDao
     abstract fun metadataDao(): MetadataDao
     abstract fun avisCritiquesDao(): AvisCritiquesDao
+    abstract fun auteursDao(): AuteursDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -47,6 +47,7 @@ data class AvisParEmissionUi(
 data class LivreDetailUi(
     val id: String,
     val titre: String,
+    val auteurId: String?,
     val auteurNom: String?,
     val editeur: String?,
     val urlBabelio: String?,
@@ -87,6 +88,19 @@ data class SearchResultUi(
     val type: String,
     val refId: String,
     val content: String
+)
+
+data class LivreParAuteurUi(
+    val livreId: String,
+    val titre: String,
+    val noteMoyenne: Double?,
+    val derniereEmissionDate: String?
+)
+
+data class AuteurDetailUi(
+    val id: String,
+    val nom: String,
+    val livres: List<LivreParAuteurUi>
 )
 
 data class DbInfoUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt
@@ -1,0 +1,32 @@
+package com.lmelp.mobile.data.repository
+
+import com.lmelp.mobile.data.db.AuteursDao
+import com.lmelp.mobile.data.model.AuteurDetailUi
+import com.lmelp.mobile.data.model.LivreParAuteurUi
+
+class AuteursRepository(
+    private val auteursDao: AuteursDao
+) {
+
+    suspend fun getAuteurDetail(auteurId: String): AuteurDetailUi? {
+        val auteur = auteursDao.getAuteurById(auteurId) ?: return null
+        val rows = auteursDao.getLivresParAuteur(auteurId)
+
+        val livres = rows
+            .sortedByDescending { it.derniereEmissionDate ?: "" }
+            .map { row ->
+                LivreParAuteurUi(
+                    livreId = row.livreId,
+                    titre = row.titre,
+                    noteMoyenne = row.noteMoyenne,
+                    derniereEmissionDate = row.derniereEmissionDate
+                )
+            }
+
+        return AuteurDetailUi(
+            id = auteur.id,
+            nom = auteur.nom,
+            livres = livres
+        )
+    }
+}

--- a/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
@@ -45,6 +45,7 @@ class LivresRepository(
         return LivreDetailUi(
             id = livre.id,
             titre = livre.titre,
+            auteurId = livre.auteurId,
             auteurNom = livre.auteurNom,
             editeur = livre.editeur,
             urlBabelio = livre.urlBabelio,

--- a/app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt
@@ -1,0 +1,122 @@
+package com.lmelp.mobile.ui.auteurs
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lmelp.mobile.data.model.LivreParAuteurUi
+import com.lmelp.mobile.data.repository.AuteursRepository
+import com.lmelp.mobile.ui.components.EmptyState
+import com.lmelp.mobile.ui.components.ErrorMessage
+import com.lmelp.mobile.ui.components.LoadingIndicator
+import com.lmelp.mobile.ui.components.NoteBadge
+import com.lmelp.mobile.ui.emissions.formatDateLong
+import com.lmelp.mobile.viewmodel.AuteurDetailViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun AuteurDetailScreen(
+    auteurId: String,
+    repository: AuteursRepository,
+    onBack: () -> Unit,
+    onLivreClick: (String) -> Unit
+) {
+    val viewModel: AuteurDetailViewModel = viewModel(
+        factory = AuteurDetailViewModel.Factory(repository, auteurId)
+    )
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(uiState.auteur?.nom ?: "Auteur") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Retour")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        when {
+            uiState.isLoading -> LoadingIndicator(Modifier.padding(padding))
+            uiState.error != null -> ErrorMessage(uiState.error!!, Modifier.padding(padding))
+            uiState.auteur != null -> {
+                val auteur = uiState.auteur!!
+                if (auteur.livres.isEmpty()) {
+                    EmptyState("Aucun livre trouvé", Modifier.padding(padding))
+                } else {
+                    LazyColumn(modifier = Modifier.padding(padding)) {
+                        items(auteur.livres, key = { it.livreId }) { livre ->
+                            LivreParAuteurCard(
+                                livre = livre,
+                                onClick = { onLivreClick(livre.livreId) }
+                            )
+                        }
+                    }
+                }
+            }
+            else -> EmptyState("Auteur introuvable", Modifier.padding(padding))
+        }
+    }
+}
+
+@Composable
+fun LivreParAuteurCard(livre: LivreParAuteurUi, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = livre.titre,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                livre.derniereEmissionDate?.let {
+                    Text(
+                        text = formatDateLong(it),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
+            }
+            livre.noteMoyenne?.let {
+                NoteBadge(
+                    note = it,
+                    modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
@@ -44,7 +44,8 @@ fun LivreDetailScreen(
     livreId: String,
     repository: LivresRepository,
     onBack: () -> Unit,
-    onEmissionClick: (String) -> Unit = {}
+    onEmissionClick: (String) -> Unit = {},
+    onAuteurClick: (String) -> Unit = {}
 ) {
     val viewModel: LivreDetailViewModel = viewModel(
         factory = LivreDetailViewModel.Factory(repository, livreId)
@@ -69,6 +70,7 @@ fun LivreDetailScreen(
             uiState.livre != null -> LivreDetailContent(
                 livre = uiState.livre!!,
                 onEmissionClick = onEmissionClick,
+                onAuteurClick = onAuteurClick,
                 modifier = Modifier.padding(padding)
             )
             else -> EmptyState("Livre introuvable", Modifier.padding(padding))
@@ -80,6 +82,7 @@ fun LivreDetailScreen(
 fun LivreDetailContent(
     livre: LivreDetailUi,
     onEmissionClick: (String) -> Unit,
+    onAuteurClick: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     LazyColumn(modifier = modifier) {
@@ -92,8 +95,18 @@ fun LivreDetailContent(
                 verticalAlignment = Alignment.Top
             ) {
                 Column(modifier = Modifier.weight(1f)) {
-                    livre.auteurNom?.let {
-                        Text(it, style = MaterialTheme.typography.bodyLarge)
+                    livre.auteurNom?.let { nom ->
+                        val auteurId = livre.auteurId
+                        Text(
+                            text = nom,
+                            style = MaterialTheme.typography.bodyLarge,
+                            color = if (auteurId != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                            modifier = if (auteurId != null) {
+                                Modifier.clickable { onAuteurClick(auteurId) }
+                            } else {
+                                Modifier
+                            }
+                        )
                     }
                     livre.editeur?.let {
                         Text(

--- a/app/src/main/java/com/lmelp/mobile/viewmodel/AuteurDetailViewModel.kt
+++ b/app/src/main/java/com/lmelp/mobile/viewmodel/AuteurDetailViewModel.kt
@@ -1,0 +1,55 @@
+package com.lmelp.mobile.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.lmelp.mobile.data.model.AuteurDetailUi
+import com.lmelp.mobile.data.repository.AuteursRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AuteurDetailUiState(
+    val isLoading: Boolean = false,
+    val auteur: AuteurDetailUi? = null,
+    val error: String? = null
+)
+
+class AuteurDetailViewModel(
+    private val repository: AuteursRepository,
+    private val auteurId: String
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AuteurDetailUiState())
+    val uiState: StateFlow<AuteurDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        loadAuteur()
+    }
+
+    private fun loadAuteur() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                val auteur = repository.getAuteurDetail(auteurId)
+                _uiState.update { it.copy(isLoading = false, auteur = auteur) }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                _uiState.update { it.copy(isLoading = false, error = e.message) }
+            }
+        }
+    }
+
+    class Factory(
+        private val repository: AuteursRepository,
+        private val auteurId: String
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return AuteurDetailViewModel(repository, auteurId) as T
+        }
+    }
+}

--- a/app/src/test/java/com/lmelp/mobile/AuteursRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/AuteursRepositoryTest.kt
@@ -1,0 +1,101 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.AuteursDao
+import com.lmelp.mobile.data.db.LivreParAuteurRow
+import com.lmelp.mobile.data.model.AuteurEntity
+import com.lmelp.mobile.data.repository.AuteursRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class AuteursRepositoryTest {
+
+    private fun makeAuteurEntity(id: String, nom: String) = AuteurEntity(
+        id = id,
+        nom = nom,
+        urlBabelio = null
+    )
+
+    private fun makeLivreParAuteurRow(
+        livreId: String,
+        titre: String,
+        noteMoyenne: Double?,
+        derniereEmissionDate: String?
+    ) = LivreParAuteurRow(
+        livreId = livreId,
+        titre = titre,
+        noteMoyenne = noteMoyenne,
+        derniereEmissionDate = derniereEmissionDate
+    )
+
+    @Test
+    fun `getAuteurDetail retourne null si auteur introuvable`() = runTest {
+        val dao = mock<AuteursDao>()
+        whenever(dao.getAuteurById(any())).thenReturn(null)
+
+        val repo = AuteursRepository(dao)
+        val result = repo.getAuteurDetail("inexistant")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `livres tries par date emission decroissante`() = runTest {
+        val dao = mock<AuteursDao>()
+        whenever(dao.getAuteurById(any())).thenReturn(makeAuteurEntity("a1", "Victor Hugo"))
+        whenever(dao.getLivresParAuteur(any())).thenReturn(
+            listOf(
+                makeLivreParAuteurRow("l1", "Notre-Dame de Paris", 8.0, "2022-01-10"),
+                makeLivreParAuteurRow("l2", "Les Misérables", 9.0, "2024-06-15"),
+                makeLivreParAuteurRow("l3", "Ruy Blas", null, "2023-03-01"),
+            )
+        )
+
+        val repo = AuteursRepository(dao)
+        val result = repo.getAuteurDetail("a1")!!
+
+        assertEquals(3, result.livres.size)
+        // Plus récent en premier
+        assertEquals("l2", result.livres[0].livreId)  // 2024
+        assertEquals("l3", result.livres[1].livreId)  // 2023
+        assertEquals("l1", result.livres[2].livreId)  // 2022
+    }
+
+    @Test
+    fun `livres sans date emission apparaissent en dernier`() = runTest {
+        val dao = mock<AuteursDao>()
+        whenever(dao.getAuteurById(any())).thenReturn(makeAuteurEntity("a1", "Victor Hugo"))
+        whenever(dao.getLivresParAuteur(any())).thenReturn(
+            listOf(
+                makeLivreParAuteurRow("l1", "Notre-Dame de Paris", 8.0, null),
+                makeLivreParAuteurRow("l2", "Les Misérables", 9.0, "2024-06-15"),
+            )
+        )
+
+        val repo = AuteursRepository(dao)
+        val result = repo.getAuteurDetail("a1")!!
+
+        assertEquals("l2", result.livres[0].livreId)  // avec date
+        assertEquals("l1", result.livres[1].livreId)  // sans date
+    }
+
+    @Test
+    fun `noteMoyenne null si livre sans avis dans palmares`() = runTest {
+        val dao = mock<AuteursDao>()
+        whenever(dao.getAuteurById(any())).thenReturn(makeAuteurEntity("a1", "Auteur"))
+        whenever(dao.getLivresParAuteur(any())).thenReturn(
+            listOf(
+                makeLivreParAuteurRow("l1", "Livre sans avis", null, "2023-01-01"),
+            )
+        )
+
+        val repo = AuteursRepository(dao)
+        val result = repo.getAuteurDetail("a1")!!
+
+        assertNull(result.livres[0].noteMoyenne)
+    }
+}

--- a/docs/claude/memory/260312-1730-issue47-fiche-auteur.md
+++ b/docs/claude/memory/260312-1730-issue47-fiche-auteur.md
@@ -1,0 +1,106 @@
+---
+name: Issue #47 — Fiche auteur
+description: Création de la fiche auteur accessible depuis la fiche livre et la recherche
+type: project
+---
+
+# Issue #47 — Fiche auteur : créer la fiche, accessible depuis un livre ou la recherche
+
+## Problème
+
+Pas de fiche auteur dans l'application. L'issue demandait :
+
+1. Créer `AuteurDetailScreen` : nom auteur + liste des livres (note moyenne + date dernière émission), livres triés par date émission décroissante, cliquables → fiche livre
+2. Modifier `LivreDetailScreen` : auteurNom cliquable → fiche auteur (seulement si `auteurId` non null)
+3. Modifier `SearchScreen` / `Navigation` : résultat de type "auteur" cliquable → fiche auteur
+
+## Architecture de la solution
+
+### Nouveau DAO
+
+`app/src/main/java/com/lmelp/mobile/data/db/AuteursDao.kt`
+
+- `LivreParAuteurRow` : data class avec `livreId`, `titre`, `noteMoyenne` (LEFT JOIN palmares), `derniereEmissionDate` (MAX(em.date) via LEFT JOIN avis → emissions)
+- Query SQL avec double LEFT JOIN :
+
+```sql
+SELECT l.id as livre_id, l.titre,
+       p.note_moyenne,
+       MAX(em.date) as derniere_emission_date
+FROM livres l
+LEFT JOIN palmares p ON p.livre_id = l.id
+LEFT JOIN avis a ON a.livre_id = l.id
+LEFT JOIN emissions em ON em.id = a.emission_id
+WHERE l.auteur_id = :auteurId
+GROUP BY l.id
+```
+
+LEFT JOIN car tous les livres n'ont pas de note dans palmares (seuil ≥ 2 avis), et certains peuvent n'avoir aucune émission.
+
+### Nouveaux modèles UI
+
+`app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt`
+
+- `LivreParAuteurUi` : `livreId`, `titre`, `noteMoyenne: Double?`, `derniereEmissionDate: String?`
+- `AuteurDetailUi` : `id`, `nom`, `livres: List<LivreParAuteurUi>`
+- `LivreDetailUi` : ajout de `auteurId: String?` (nouveau champ) pour permettre la navigation vers la fiche auteur
+
+### Logique de tri dans le Repository
+
+`app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt`
+
+- Tri par `derniereEmissionDate` décroissant (les `null` passent en dernier via `sortedByDescending { it.derniereEmissionDate ?: "" }`)
+
+### `LivresRepository` mis à jour
+
+`app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt`
+
+- Propage `livre.auteurId` dans le `LivreDetailUi` retourné
+
+### ViewModel
+
+`app/src/main/java/com/lmelp/mobile/viewmodel/AuteurDetailViewModel.kt`
+
+Pattern identique aux autres ViewModels : `AuteurDetailUiState(isLoading, auteur, error)` + `Factory`.
+
+### UI
+
+`app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt`
+
+- `AuteurDetailScreen` : Scaffold + TopAppBar (nom auteur) + `LazyColumn` de `LivreParAuteurCard`
+- `LivreParAuteurCard` : Row avec titre + date émission (à gauche) et `NoteBadge` (à droite), cliquable
+
+### LivreDetailScreen mis à jour
+
+`app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt`
+
+- Ajout paramètre `onAuteurClick: (String) -> Unit = {}`
+- `auteurNom` affiché en `colorScheme.primary` et cliquable si `auteurId != null`, sinon texte normal non cliquable
+
+### Navigation
+
+`app/src/main/java/com/lmelp/mobile/Navigation.kt`
+
+- Ajout `Routes.AUTEUR_DETAIL = "auteur/{auteurId}"` + `Routes.auteurDetail(id)`
+- Nouveau composable `AUTEUR_DETAIL` avec `navArgument("auteurId")`
+- `LIVRE_DETAIL` : passage de `onAuteurClick = { navController.navigate(Routes.auteurDetail(it)) }`
+- `SEARCH` : ajout `"auteur" -> navController.navigate(Routes.auteurDetail(id))` dans le `when`
+
+### Infrastructure
+
+- `app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt` : expose `abstract fun auteursDao(): AuteursDao`
+- `app/src/main/java/com/lmelp/mobile/LmelpApp.kt` : expose `val auteursRepository by lazy { AuteursRepository(database.auteursDao()) }`
+
+## Tests TDD
+
+`app/src/test/java/com/lmelp/mobile/AuteursRepositoryTest.kt`
+
+4 tests unitaires :
+- `getAuteurDetail retourne null si auteur introuvable`
+- `livres tries par date emission decroissante`
+- `livres sans date emission apparaissent en dernier`
+- `noteMoyenne null si livre sans avis dans palmares`
+
+## Pattern LEFT JOIN palmares
+
+La table `palmares` ne contient que les livres avec ≥ 2 avis. Pour afficher tous les livres d'un auteur (y compris ceux sans note), utiliser `LEFT JOIN palmares` → `noteMoyenne` sera `null` pour les livres non présents dans palmares.


### PR DESCRIPTION
## Summary

- Nouveau `AuteurDetailScreen` : nom auteur en titre + liste des livres triés par date d'émission décroissante, chaque livre affiche sa note moyenne (`NoteBadge`) et la date de la dernière émission
- `LivreDetailScreen` : l'auteur est désormais cliquable (couleur primary) quand un `auteurId` est disponible → navigation vers la fiche auteur
- `SearchScreen` / `Navigation` : les résultats de type "auteur" sont maintenant cliquables → fiche auteur

## Détails techniques

- `AuteursDao` : query avec `LEFT JOIN palmares` (note moyenne, optionnelle car seuil ≥ 2 avis) + `MAX(em.date)` pour la date de dernière émission
- `LivreDetailUi` enrichi de `auteurId` pour permettre la navigation
- 4 tests TDD (`AuteursRepositoryTest`) : tri par date, nulls en dernier, auteur inexistant, note null

## Test plan

- [ ] Ouvrir la fiche d'un livre → l'auteur apparaît en bleu et est cliquable → fiche auteur s'ouvre avec ses livres triés
- [ ] Depuis la fiche auteur, cliquer sur un livre → fiche livre
- [ ] Rechercher un auteur (ex: "Hugo") → cliquer sur le résultat de type "auteur" → fiche auteur
- [ ] Vérifier qu'un livre sans `auteurId` affiche le nom en texte non cliquable

🤖 Generated with [Claude Code](https://claude.com/claude-code)