### PR TITLE
fix(#66): restaurer le tap sur les blocs HomeScreen + ajustements UI Recherche

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/ui/home/HomeScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/home/HomeScreen.kt
@@ -11,7 +11,9 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxScope
@@ -204,6 +206,22 @@ fun HeroSection(
 
 private val SWIPE_THRESHOLD_DP = 60.dp
 
+/** Actions possibles résultant d'un geste sur un DashboardCard. */
+enum class GestureAction { TAP, SWIPE_LEFT, SWIPE_RIGHT }
+
+/**
+ * Résout le geste en action selon le déplacement total accumulé.
+ * Extraite en fonction pure pour faciliter les tests unitaires.
+ *
+ * @param totalDragX déplacement horizontal total (px). 0f = tap pur.
+ * @param thresholdPx seuil (px) au-delà duquel le geste est considéré comme swipe.
+ */
+internal fun resolveGestureAction(totalDragX: Float, thresholdPx: Float): GestureAction = when {
+    totalDragX < -thresholdPx -> GestureAction.SWIPE_LEFT
+    totalDragX > thresholdPx -> GestureAction.SWIPE_RIGHT
+    else -> GestureAction.TAP
+}
+
 /**
  * Carte de dashboard avec fond animé (rotation de couvertures via AnimatedContent) ou couleur unie.
  * La direction du swipe (gauche=-1, droite=+1) détermine le sens de l'animation de slide.
@@ -227,28 +245,28 @@ fun DashboardCard(
     val swipeModifier = if (onSwipeLeft != null || onSwipeRight != null) {
         Modifier.pointerInput(Unit) {
             val thresholdPx = SWIPE_THRESHOLD_DP.toPx()
-            detectHorizontalDragGestures(
-                onDragStart = { totalDragX = 0f },
-                onHorizontalDrag = { change, dragAmount ->
+            awaitEachGesture {
+                val down = awaitFirstDown(requireUnconsumed = false)
+                totalDragX = 0f
+                // Accumule le drag horizontal jusqu'au relâchement
+                horizontalDrag(down.id) { change ->
                     change.consume()
-                    totalDragX += dragAmount
-                },
-                onDragEnd = {
-                    when {
-                        totalDragX < -thresholdPx -> {
-                            slideDirection = -1
-                            onSwipeLeft?.invoke()
-                        }
-                        totalDragX > thresholdPx -> {
-                            slideDirection = 1
-                            onSwipeRight?.invoke()
-                        }
-                        else -> onClick()
+                    totalDragX += change.position.x - change.previousPosition.x
+                }
+                // Résout l'action : tap, swipe gauche ou swipe droite
+                when (resolveGestureAction(totalDragX, thresholdPx)) {
+                    GestureAction.SWIPE_LEFT -> {
+                        slideDirection = -1
+                        onSwipeLeft?.invoke()
                     }
-                    totalDragX = 0f
-                },
-                onDragCancel = { totalDragX = 0f }
-            )
+                    GestureAction.SWIPE_RIGHT -> {
+                        slideDirection = 1
+                        onSwipeRight?.invoke()
+                    }
+                    GestureAction.TAP -> onClick()
+                }
+                totalDragX = 0f
+            }
         }
     } else {
         Modifier.clickable(onClick = onClick)
@@ -556,8 +574,8 @@ fun NavTilesGrid(
                     .weight(1.5f)
                     .fillMaxHeight(),
                 shape = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(containerColor = Color.White),
-                border = androidx.compose.foundation.BorderStroke(1.5.dp, LmelpVert)
+                colors = CardDefaults.cardColors(containerColor = Color(0xFFF7F7F7)),
+                border = androidx.compose.foundation.BorderStroke(6.dp, LmelpVert)
             ) {
                 Column(modifier = Modifier.fillMaxSize()) {
                     // Bandeau vert avec titre "Recherche" en haut à gauche
@@ -578,8 +596,9 @@ fun NavTilesGrid(
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(horizontal = 12.dp, vertical = 10.dp),
-                        verticalArrangement = Arrangement.Center
+                            .padding(horizontal = 12.dp)
+                            .padding(top = 8.dp),
+                        verticalArrangement = Arrangement.Top
                     ) {
                         Row(
                             modifier = Modifier

--- a/app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt
@@ -82,7 +82,8 @@ fun SearchContent(
             onActiveChange = {},
             placeholder = { Text("Rechercher un livre, auteur, critique...") },
             leadingIcon = { Icon(Icons.Default.Search, contentDescription = null) },
-            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp)
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 8.dp),
+            windowInsets = WindowInsets(0)
         ) {}
 
         when {

--- a/app/src/test/java/com/lmelp/mobile/DashboardCardGestureTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/DashboardCardGestureTest.kt
@@ -1,0 +1,64 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.ui.home.GestureAction
+import com.lmelp.mobile.ui.home.resolveGestureAction
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests pour la logique de résolution du geste sur DashboardCard.
+ *
+ * Un tap pur (doigt levé sans déplacement) doit déclencher onClick,
+ * pas être ignoré. Bug #66 : detectHorizontalDragGestures ignorait les taps.
+ *
+ * Règles :
+ *  - totalDragX == 0f  → TAP (doigt levé sans mouvement)
+ *  - |totalDragX| < threshold → TAP (micro-mouvement, traité comme tap)
+ *  - totalDragX < -threshold → SWIPE_LEFT (page suivante)
+ *  - totalDragX > +threshold → SWIPE_RIGHT (page précédente)
+ */
+class DashboardCardGestureTest {
+
+    private val threshold = 60f
+
+    // --- Tap pur ---
+
+    @Test
+    fun `tap pur sans mouvement declenche TAP`() {
+        assertEquals(GestureAction.TAP, resolveGestureAction(0f, threshold))
+    }
+
+    // --- Micro-mouvements traités comme tap ---
+
+    @Test
+    fun `micro-mouvement positif sous le seuil declenche TAP`() {
+        assertEquals(GestureAction.TAP, resolveGestureAction(30f, threshold))
+    }
+
+    @Test
+    fun `micro-mouvement negatif sous le seuil declenche TAP`() {
+        assertEquals(GestureAction.TAP, resolveGestureAction(-30f, threshold))
+    }
+
+    @Test
+    fun `mouvement exactement au seuil declenche TAP`() {
+        assertEquals(GestureAction.TAP, resolveGestureAction(60f, threshold))
+        assertEquals(GestureAction.TAP, resolveGestureAction(-60f, threshold))
+    }
+
+    // --- Swipe gauche (page suivante) ---
+
+    @Test
+    fun `swipe gauche au-dela du seuil declenche SWIPE_LEFT`() {
+        assertEquals(GestureAction.SWIPE_LEFT, resolveGestureAction(-61f, threshold))
+        assertEquals(GestureAction.SWIPE_LEFT, resolveGestureAction(-200f, threshold))
+    }
+
+    // --- Swipe droite (page précédente) ---
+
+    @Test
+    fun `swipe droite au-dela du seuil declenche SWIPE_RIGHT`() {
+        assertEquals(GestureAction.SWIPE_RIGHT, resolveGestureAction(61f, threshold))
+        assertEquals(GestureAction.SWIPE_RIGHT, resolveGestureAction(200f, threshold))
+    }
+}

--- a/docs/claude/memory/260317-2200-issue66-click-blocs-homescreen.md
+++ b/docs/claude/memory/260317-2200-issue66-click-blocs-homescreen.md
@@ -1,0 +1,58 @@
+# Issue #66 — Fix click sur blocs émissions/palmarès/conseils + ajustements UI bloc Recherche
+
+## Contexte
+
+Suite au PR #59 (swipe local par bloc), les taps sur les blocs de la HomeScreen ne naviguaient plus vers les écrans correspondants.
+
+## Cause racine
+
+`DashboardCard` utilisait `detectHorizontalDragGestures` pour gérer swipe + fallback tap. Problème : ce gesture detector **ne détecte que les drags** — un tap pur (touch down + up sans mouvement) n'appelle jamais `onDragEnd`, donc `else -> onClick()` n'était jamais exécuté.
+
+## Fix TDD
+
+### Fonction pure extraite (testable)
+
+Dans `app/src/main/java/com/lmelp/mobile/ui/home/HomeScreen.kt` :
+
+```kotlin
+enum class GestureAction { TAP, SWIPE_LEFT, SWIPE_RIGHT }
+
+internal fun resolveGestureAction(totalDragX: Float, thresholdPx: Float): GestureAction = when {
+    totalDragX < -thresholdPx -> GestureAction.SWIPE_LEFT
+    totalDragX > thresholdPx -> GestureAction.SWIPE_RIGHT
+    else -> GestureAction.TAP
+}
+```
+
+9 tests unitaires dans `app/src/test/java/com/lmelp/mobile/DashboardCardGestureTest.kt` couvrent : tap pur (0f), micro-mouvements (< 60dp = TAP), swipe gauche/droite (> 60dp).
+
+### Remplacement du gesture detector
+
+`detectHorizontalDragGestures` → `awaitEachGesture` + `awaitFirstDown` + `horizontalDrag` :
+
+- `awaitFirstDown` : capture le touch down (tap ET drag)
+- `horizontalDrag` : accumule le déplacement jusqu'au relâchement (retourne immédiatement si pas de drag = tap pur)
+- `resolveGestureAction` : décide TAP / SWIPE_LEFT / SWIPE_RIGHT
+
+**Clé** : `horizontalDrag` retourne immédiatement si le doigt est levé sans bouger → `totalDragX` reste 0f → `resolveGestureAction` retourne `TAP` → `onClick()` est appelé.
+
+## Ajustements UI bloc Recherche (HomeScreen)
+
+- Fond : `Color.White` → `Color(0xFFF7F7F7)` (gris très léger ~10%)
+- Bordure verte : 1.5dp → 6dp
+- Mini barre de recherche : centrée verticalement → collée à 8dp sous la zone verte (`Arrangement.Top` + `padding(top = 8.dp)`)
+
+## Ajustements UI écran Recherche (SearchScreen)
+
+- `SearchBar` : ajout de `windowInsets = WindowInsets(0)` pour supprimer le padding interne Material3
+- `vertical = 8.dp` conservé pour espacer proprement sous la TopAppBar
+
+## Piège à retenir
+
+`detectHorizontalDragGestures` ignore les taps purs. Quand on veut gérer **à la fois taps et swipes** sur un même composable, utiliser `awaitEachGesture` + `awaitFirstDown` + `horizontalDrag`.
+
+## Fichiers modifiés
+
+- `app/src/main/java/com/lmelp/mobile/ui/home/HomeScreen.kt`
+- `app/src/main/java/com/lmelp/mobile/ui/search/SearchScreen.kt`
+- `app/src/test/java/com/lmelp/mobile/DashboardCardGestureTest.kt` (nouveau)


### PR DESCRIPTION
## Summary

- **Bug fix** : les taps sur les blocs Émissions/Palmarès/Conseils ne déclenchaient plus la navigation suite au PR #59. Cause : `detectHorizontalDragGestures` ignore les taps purs. Remplacé par `awaitEachGesture` + `awaitFirstDown` + `horizontalDrag` qui gère les deux cas.
- **TDD** : `resolveGestureAction()` extraite en fonction pure testable (9 tests RED→GREEN dans `DashboardCardGestureTest`)
- **UI bloc Recherche (HomeScreen)** : fond gris léger `0xFFF7F7F7`, bordure verte 6dp, mini barre à 8dp sous la zone verte
- **UI écran Recherche** : `windowInsets = WindowInsets(0)` sur `SearchBar` + vertical padding 8dp

## Test plan

- [ ] Tapper sur le bloc Émissions → navigue vers l'écran Émissions
- [ ] Tapper sur le bloc Palmarès → navigue vers l'écran Palmarès
- [ ] Tapper sur le bloc Conseils → navigue vers l'écran Conseils
- [ ] Swipe gauche/droite sur chaque bloc → change le livre affiché (pas de navigation)
- [ ] Bloc Recherche : fond légèrement gris, bordure verte épaisse, mini barre en haut
- [ ] Écran Recherche : barre de recherche positionnée à 8dp sous la TopAppBar

🤖 Generated with [Claude Code](https://claude.com/claude-code)