### PR TITLE
feat(#71): ajouter tri Note conseil dans Sur ma liseuse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,11 @@ Application Android **offline-first** pour consulter le contenu de Le Masque et 
 - **adb** : `/home/vscode/android-sdk/platform-tools/adb` (pas dans le PATH par défaut)
 - **MongoDB** : port **27018** (pas 27017)
 - **Calibre** : `/home/vscode/Calibre Library/metadata.db`, virtual library `guillaume`
+- **sqlite3** : disponible via le venv Python — toujours activer avant usage :
+  ```bash
+  source /workspaces/lmelp-mobile/.venv/bin/activate
+  sqlite3 app/src/main/assets/lmelp.db "..."
+  ```
 
 ## Commandes essentielles
 

--- a/app/src/main/java/com/lmelp/mobile/data/db/OnKindleDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/OnKindleDao.kt
@@ -1,17 +1,35 @@
 package com.lmelp.mobile.data.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Query
 import com.lmelp.mobile.data.model.OnKindleEntity
+
+data class OnKindleAvecConseilRow(
+    @ColumnInfo(name = "livre_id")      val livreId: String,
+    val titre: String,
+    @ColumnInfo(name = "auteur_nom")    val auteurNom: String?,
+    @ColumnInfo(name = "url_babelio")   val urlBabelio: String?,
+    @ColumnInfo(name = "url_cover")     val urlCover: String?,
+    @ColumnInfo(name = "calibre_lu")    val calibreLu: Int,
+    @ColumnInfo(name = "calibre_rating") val calibreRating: Double?,
+    @ColumnInfo(name = "note_moyenne")  val noteMoyenne: Double?,
+    @ColumnInfo(name = "nb_avis")       val nbAvis: Int,
+    @ColumnInfo(name = "score_hybride") val scoreHybride: Double?
+)
 
 @Dao
 interface OnKindleDao {
 
     @Query("""
-        SELECT * FROM onkindle
-        WHERE (:afficherLus = 1 AND calibre_lu = 1) OR (:afficherNonLus = 1 AND calibre_lu = 0)
+        SELECT ok.livre_id, ok.titre, ok.auteur_nom, ok.url_babelio, ok.url_cover,
+               ok.calibre_lu, ok.calibre_rating, ok.note_moyenne, ok.nb_avis,
+               r.score_hybride
+        FROM onkindle ok
+        LEFT JOIN recommendations r ON r.livre_id = ok.livre_id
+        WHERE (:afficherLus = 1 AND ok.calibre_lu = 1) OR (:afficherNonLus = 1 AND ok.calibre_lu = 0)
     """)
-    suspend fun getOnKindleFiltres(afficherLus: Int, afficherNonLus: Int): List<OnKindleEntity>
+    suspend fun getOnKindleAvecConseil(afficherLus: Int, afficherNonLus: Int): List<OnKindleAvecConseilRow>
 
     @Query("SELECT * FROM onkindle WHERE url_babelio IS NOT NULL LIMIT :limit")
     suspend fun getTopOnKindleAvecUrl(limit: Int): List<OnKindleEntity>

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -132,7 +132,8 @@ data class OnKindleUi(
     val noteMoyenne: Double?,
     val nbAvis: Int,
     val discusseAuMasque: Boolean = noteMoyenne != null,
-    val urlCover: String? = null
+    val urlCover: String? = null,
+    val scoreHybride: Double? = null
 )
 
 data class DbInfoUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/OnKindleRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/OnKindleRepository.kt
@@ -1,8 +1,9 @@
 package com.lmelp.mobile.data.repository
 
+import com.lmelp.mobile.data.db.OnKindleAvecConseilRow
 import com.lmelp.mobile.data.db.OnKindleDao
-import com.lmelp.mobile.data.model.OnKindleEntity
 import com.lmelp.mobile.data.model.OnKindleUi
+import com.lmelp.mobile.viewmodel.TriMode
 import java.text.Collator
 import java.util.Locale
 
@@ -13,20 +14,26 @@ class OnKindleRepository(private val dao: OnKindleDao) {
     suspend fun getOnKindle(
         afficherLus: Boolean,
         afficherNonLus: Boolean,
-        triParNote: Boolean
+        triMode: TriMode
     ): List<OnKindleUi> {
-        val entities = dao.getOnKindleFiltres(
+        val rows = dao.getOnKindleAvecConseil(
             afficherLus = if (afficherLus) 1 else 0,
             afficherNonLus = if (afficherNonLus) 1 else 0
         )
-        val sorted = if (triParNote) {
-            entities.sortedWith(
-                compareBy<OnKindleEntity> { if (it.noteMoyenne == null) 1 else 0 }
+        val sorted = when (triMode) {
+            TriMode.ALPHA -> rows.sortedWith(
+                Comparator { a, b -> collator.compare(a.titre, b.titre) }
+            )
+            TriMode.NOTE_MASQUE -> rows.sortedWith(
+                compareBy<OnKindleAvecConseilRow> { if (it.noteMoyenne == null) 1 else 0 }
                     .thenByDescending { it.noteMoyenne ?: 0.0 }
                     .thenWith(collator) { it.titre }
             )
-        } else {
-            entities.sortedWith(Comparator { a, b -> collator.compare(a.titre, b.titre) })
+            TriMode.NOTE_CONSEIL -> rows.sortedWith(
+                compareBy<OnKindleAvecConseilRow> { if (it.scoreHybride == null) 1 else 0 }
+                    .thenByDescending { it.scoreHybride ?: 0.0 }
+                    .thenWith(collator) { it.titre }
+            )
         }
         return sorted.map { it.toUi() }
     }
@@ -34,7 +41,7 @@ class OnKindleRepository(private val dao: OnKindleDao) {
     private fun <T> Comparator<T>.thenWith(collator: Collator, key: (T) -> String): Comparator<T> =
         thenComparator { a, b -> collator.compare(key(a), key(b)) }
 
-    private fun OnKindleEntity.toUi() = OnKindleUi(
+    private fun OnKindleAvecConseilRow.toUi() = OnKindleUi(
         livreId = livreId,
         titre = titre,
         auteurNom = auteurNom,
@@ -43,6 +50,7 @@ class OnKindleRepository(private val dao: OnKindleDao) {
         noteMoyenne = noteMoyenne,
         nbAvis = nbAvis,
         discusseAuMasque = noteMoyenne != null,
-        urlCover = urlCover
+        urlCover = urlCover,
+        scoreHybride = scoreHybride
     )
 }

--- a/app/src/main/java/com/lmelp/mobile/ui/onkindle/OnKindleScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/onkindle/OnKindleScreen.kt
@@ -47,6 +47,7 @@ import com.lmelp.mobile.ui.components.NoteBadge
 import com.lmelp.mobile.ui.theme.LmelpVert
 import com.lmelp.mobile.viewmodel.OnKindleUiState
 import com.lmelp.mobile.viewmodel.OnKindleViewModel
+import com.lmelp.mobile.viewmodel.TriMode
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -78,7 +79,7 @@ fun OnKindleScreen(
             onLivreClick = onLivreClick,
             onToggleLus = { viewModel.setAfficherLus(!uiState.afficherLus) },
             onToggleNonLus = { viewModel.setAfficherNonLus(!uiState.afficherNonLus) },
-            onToggleTriParNote = { viewModel.setTriParNote(!uiState.triParNote) },
+            onSetTriMode = { viewModel.setTriMode(it) },
             modifier = Modifier.padding(padding)
         )
     }
@@ -90,7 +91,7 @@ fun OnKindleContent(
     onLivreClick: (String) -> Unit,
     onToggleLus: () -> Unit,
     onToggleNonLus: () -> Unit,
-    onToggleTriParNote: () -> Unit,
+    onSetTriMode: (TriMode) -> Unit,
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
@@ -111,15 +112,28 @@ fun OnKindleContent(
                 onClick = onToggleLus,
                 label = { Text("Lus") }
             )
+        }
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 2.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
             FilterChip(
-                selected = !uiState.triParNote,
-                onClick = { if (uiState.triParNote) onToggleTriParNote() },
+                selected = uiState.triMode == TriMode.ALPHA,
+                onClick = { onSetTriMode(TriMode.ALPHA) },
                 label = { Text("a→z") }
             )
             FilterChip(
-                selected = uiState.triParNote,
-                onClick = { if (!uiState.triParNote) onToggleTriParNote() },
-                label = { Text("Note ↓") }
+                selected = uiState.triMode == TriMode.NOTE_MASQUE,
+                onClick = { onSetTriMode(TriMode.NOTE_MASQUE) },
+                label = { Text("Note masque ↓") }
+            )
+            FilterChip(
+                selected = uiState.triMode == TriMode.NOTE_CONSEIL,
+                onClick = { onSetTriMode(TriMode.NOTE_CONSEIL) },
+                label = { Text("Note conseil ↓") }
             )
             Spacer(modifier = Modifier.weight(1f))
             Box(

--- a/app/src/main/java/com/lmelp/mobile/viewmodel/OnKindleViewModel.kt
+++ b/app/src/main/java/com/lmelp/mobile/viewmodel/OnKindleViewModel.kt
@@ -12,13 +12,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+enum class TriMode { ALPHA, NOTE_MASQUE, NOTE_CONSEIL }
+
 data class OnKindleUiState(
     val isLoading: Boolean = false,
     val livres: List<OnKindleUi> = emptyList(),
     val error: String? = null,
     val afficherLus: Boolean = true,
     val afficherNonLus: Boolean = true,
-    val triParNote: Boolean = false
+    val triMode: TriMode = TriMode.ALPHA
 )
 
 class OnKindleViewModel(private val repository: OnKindleRepository) : ViewModel() {
@@ -40,8 +42,8 @@ class OnKindleViewModel(private val repository: OnKindleRepository) : ViewModel(
         loadOnKindle()
     }
 
-    fun setTriParNote(tri: Boolean) {
-        _uiState.update { it.copy(triParNote = tri) }
+    fun setTriMode(mode: TriMode) {
+        _uiState.update { it.copy(triMode = mode) }
         loadOnKindle()
     }
 
@@ -53,7 +55,7 @@ class OnKindleViewModel(private val repository: OnKindleRepository) : ViewModel(
                 val livres = repository.getOnKindle(
                     afficherLus = state.afficherLus,
                     afficherNonLus = state.afficherNonLus,
-                    triParNote = state.triParNote
+                    triMode = state.triMode
                 )
                 _uiState.update { it.copy(isLoading = false, livres = livres, error = null) }
             } catch (e: Exception) {

--- a/app/src/test/java/com/lmelp/mobile/OnKindleViewModelTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/OnKindleViewModelTest.kt
@@ -1,9 +1,10 @@
 package com.lmelp.mobile
 
+import com.lmelp.mobile.data.db.OnKindleAvecConseilRow
 import com.lmelp.mobile.data.db.OnKindleDao
-import com.lmelp.mobile.data.model.OnKindleEntity
 import com.lmelp.mobile.data.repository.OnKindleRepository
 import com.lmelp.mobile.viewmodel.OnKindleViewModel
+import com.lmelp.mobile.viewmodel.TriMode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -37,28 +38,31 @@ class OnKindleViewModelTest {
         Dispatchers.resetMain()
     }
 
-    private fun fakeEntity(
+    private fun fakeRow(
         livreId: String,
         titre: String,
         calibreLu: Int = 0,
         noteMoyenne: Double? = null,
-        nbAvis: Int = 0
-    ) = OnKindleEntity(
+        nbAvis: Int = 0,
+        scoreHybride: Double? = null
+    ) = OnKindleAvecConseilRow(
         livreId = livreId,
         titre = titre,
         auteurNom = null,
         urlBabelio = null,
+        urlCover = null,
         calibreLu = calibreLu,
         calibreRating = null,
         noteMoyenne = noteMoyenne,
-        nbAvis = nbAvis
+        nbAvis = nbAvis,
+        scoreHybride = scoreHybride
     )
 
     @Test
-    fun `par defaut afficherLus=true afficherNonLus=true triParNote=false`() = runTest {
+    fun `par defaut afficherLus=true afficherNonLus=true triMode=ALPHA`() = runTest {
         val dao = mock<OnKindleDao>()
-        whenever(dao.getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1)).thenReturn(
-            listOf(fakeEntity("id1", "Aventure"), fakeEntity("id2", "Zorro"))
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+            listOf(fakeRow("id1", "Aventure"), fakeRow("id2", "Zorro"))
         )
         val repo = OnKindleRepository(dao)
         val viewModel = OnKindleViewModel(repo)
@@ -69,21 +73,21 @@ class OnKindleViewModelTest {
         assertFalse(state.isLoading)
         assertTrue(state.afficherLus)
         assertTrue(state.afficherNonLus)
-        assertFalse(state.triParNote)
+        assertEquals(TriMode.ALPHA, state.triMode)
         assertEquals(2, state.livres.size)
         assertEquals("Aventure", state.livres[0].titre)
         assertNull(state.error)
-        verify(dao).getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1)
+        verify(dao).getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)
     }
 
     @Test
     fun `setAfficherLus false affiche seulement non lus`() = runTest {
         val dao = mock<OnKindleDao>()
-        whenever(dao.getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1)).thenReturn(
-            listOf(fakeEntity("id1", "Livre Lu", calibreLu = 1), fakeEntity("id2", "Livre Non Lu"))
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+            listOf(fakeRow("id1", "Livre Lu", calibreLu = 1), fakeRow("id2", "Livre Non Lu"))
         )
-        whenever(dao.getOnKindleFiltres(afficherLus = 0, afficherNonLus = 1)).thenReturn(
-            listOf(fakeEntity("id2", "Livre Non Lu"))
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 0, afficherNonLus = 1)).thenReturn(
+            listOf(fakeRow("id2", "Livre Non Lu"))
         )
         val repo = OnKindleRepository(dao)
         val viewModel = OnKindleViewModel(repo)
@@ -100,24 +104,24 @@ class OnKindleViewModelTest {
     }
 
     @Test
-    fun `setTriParNote true trie par note decroissante`() = runTest {
+    fun `setTriMode NOTE_MASQUE trie par noteMoyenne decroissante`() = runTest {
         val dao = mock<OnKindleDao>()
-        whenever(dao.getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
             listOf(
-                fakeEntity("id1", "Moyen", noteMoyenne = 7.0, nbAvis = 3),
-                fakeEntity("id2", "Excellent", noteMoyenne = 9.5, nbAvis = 4),
-                fakeEntity("id3", "Sans note", noteMoyenne = null, nbAvis = 0)
+                fakeRow("id1", "Moyen", noteMoyenne = 7.0, nbAvis = 3),
+                fakeRow("id2", "Excellent", noteMoyenne = 9.5, nbAvis = 4),
+                fakeRow("id3", "Sans note", noteMoyenne = null, nbAvis = 0)
             )
         )
         val repo = OnKindleRepository(dao)
         val viewModel = OnKindleViewModel(repo)
         advanceUntilIdle()
 
-        viewModel.setTriParNote(true)
+        viewModel.setTriMode(TriMode.NOTE_MASQUE)
         advanceUntilIdle()
 
         val state = viewModel.uiState.value
-        assertTrue(state.triParNote)
+        assertEquals(TriMode.NOTE_MASQUE, state.triMode)
         assertEquals(3, state.livres.size)
         assertEquals("Excellent", state.livres[0].titre)
         assertEquals("Moyen", state.livres[1].titre)
@@ -125,13 +129,52 @@ class OnKindleViewModelTest {
     }
 
     @Test
+    fun `setTriMode NOTE_CONSEIL trie par scoreHybride decroissant livres sans conseil en dernier`() = runTest {
+        val dao = mock<OnKindleDao>()
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+            listOf(
+                fakeRow("id1", "Moyen conseil", scoreHybride = 6.5),
+                fakeRow("id2", "Top conseil", scoreHybride = 8.0),
+                fakeRow("id3", "Hors recommendations", scoreHybride = null)
+            )
+        )
+        val repo = OnKindleRepository(dao)
+        val viewModel = OnKindleViewModel(repo)
+        advanceUntilIdle()
+
+        viewModel.setTriMode(TriMode.NOTE_CONSEIL)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(TriMode.NOTE_CONSEIL, state.triMode)
+        assertEquals(3, state.livres.size)
+        assertEquals("Top conseil", state.livres[0].titre)
+        assertEquals("Moyen conseil", state.livres[1].titre)
+        assertEquals("Hors recommendations", state.livres[2].titre)
+    }
+
+    @Test
+    fun `scoreHybride propage dans OnKindleUi`() = runTest {
+        val dao = mock<OnKindleDao>()
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+            listOf(fakeRow("id1", "Avec conseil", scoreHybride = 7.8))
+        )
+        val repo = OnKindleRepository(dao)
+        val viewModel = OnKindleViewModel(repo)
+        advanceUntilIdle()
+
+        val livre = viewModel.uiState.value.livres[0]
+        assertEquals(7.8, livre.scoreHybride!!, 0.001)
+    }
+
+    @Test
     fun `tri az insensible aux accents`() = runTest {
         val dao = mock<OnKindleDao>()
-        whenever(dao.getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
             listOf(
-                fakeEntity("id1", "Zorro"),
-                fakeEntity("id2", "À prendre ou à laisser"),
-                fakeEntity("id3", "Aventure")
+                fakeRow("id1", "Zorro"),
+                fakeRow("id2", "À prendre ou à laisser"),
+                fakeRow("id3", "Aventure")
             )
         )
         val repo = OnKindleRepository(dao)
@@ -147,10 +190,10 @@ class OnKindleViewModelTest {
     @Test
     fun `livre discute au masque a discusseAuMasque=true`() = runTest {
         val dao = mock<OnKindleDao>()
-        whenever(dao.getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
             listOf(
-                fakeEntity("id1", "Discuté", noteMoyenne = 8.5, nbAvis = 4),
-                fakeEntity("id2", "Non discuté", noteMoyenne = null, nbAvis = 0)
+                fakeRow("id1", "Discuté", noteMoyenne = 8.5, nbAvis = 4),
+                fakeRow("id2", "Non discuté", noteMoyenne = null, nbAvis = 0)
             )
         )
         val repo = OnKindleRepository(dao)
@@ -165,7 +208,7 @@ class OnKindleViewModelTest {
     @Test
     fun `error case expose erreur dans uiState`() = runTest {
         val dao = mock<OnKindleDao>()
-        whenever(dao.getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1))
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1))
             .thenThrow(RuntimeException("DB error"))
         val repo = OnKindleRepository(dao)
         val viewModel = OnKindleViewModel(repo)
@@ -181,10 +224,10 @@ class OnKindleViewModelTest {
     @Test
     fun `les deux filtres off retourne liste vide`() = runTest {
         val dao = mock<OnKindleDao>()
-        whenever(dao.getOnKindleFiltres(afficherLus = 1, afficherNonLus = 1)).thenReturn(
-            listOf(fakeEntity("id1", "Livre A"))
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1)).thenReturn(
+            listOf(fakeRow("id1", "Livre A"))
         )
-        whenever(dao.getOnKindleFiltres(afficherLus = 0, afficherNonLus = 0)).thenReturn(emptyList())
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 0, afficherNonLus = 0)).thenReturn(emptyList())
         val repo = OnKindleRepository(dao)
         val viewModel = OnKindleViewModel(repo)
         advanceUntilIdle()

--- a/docs/claude/memory/260318-1212-issue71-onkindle-tri-conseil.md
+++ b/docs/claude/memory/260318-1212-issue71-onkindle-tri-conseil.md
@@ -1,0 +1,100 @@
+# Issue #71 — Sur ma liseuse : ajouter un tri conseil
+
+**Date** : 2026-03-18
+**Branche** : `71-sur-ma-liseuse-ajouter-un-tri-conseil`
+
+## Contexte
+
+L'écran "Sur ma liseuse" (OnKindle) disposait de 2 options de tri :
+- `a→z` (alphabétique)
+- `Note ↓` (par `note_moyenne` = note Masque)
+
+L'issue demandait d'ajouter un 3ème tri : **Note conseil ↓** (par `score_hybride` de la table `recommendations`).
+
+## Solution — remplacement du booléen par un enum TriMode
+
+### Enum `TriMode`
+
+`app/src/main/java/com/lmelp/mobile/viewmodel/OnKindleViewModel.kt` :
+```kotlin
+enum class TriMode { ALPHA, NOTE_MASQUE, NOTE_CONSEIL }
+```
+Remplace le booléen `triParNote: Boolean` dans `OnKindleUiState`.
+Méthode `setTriParNote(Boolean)` → `setTriMode(TriMode)`.
+
+### Nouveau LEFT JOIN au niveau DAO
+
+`app/src/main/java/com/lmelp/mobile/data/db/OnKindleDao.kt` — nouvelle data class de projection (pas `@Entity`, pas de migration Room) :
+```kotlin
+data class OnKindleAvecConseilRow(
+    @ColumnInfo(name = "livre_id")      val livreId: String,
+    // ... tous les champs de onkindle ...
+    @ColumnInfo(name = "score_hybride") val scoreHybride: Double?  // null si absent de recommendations
+)
+```
+
+Requête avec LEFT JOIN :
+```sql
+SELECT ok.*, r.score_hybride
+FROM onkindle ok
+LEFT JOIN recommendations r ON r.livre_id = ok.livre_id
+WHERE (:afficherLus = 1 AND ok.calibre_lu = 1) OR (:afficherNonLus = 1 AND ok.calibre_lu = 0)
+```
+
+Les livres absents de `recommendations` (ex: livres Calibre hors LMELP) ont `scoreHybride = null`
+et sont triés en dernier dans le mode NOTE_CONSEIL (même pattern que `noteMoyenne = null` en NOTE_MASQUE).
+
+### Repository — 3 branches de tri
+
+`app/src/main/java/com/lmelp/mobile/data/repository/OnKindleRepository.kt` :
+```kotlin
+when (triMode) {
+    TriMode.ALPHA       -> rows.sortedWith(Comparator { a, b -> collator.compare(a.titre, b.titre) })
+    TriMode.NOTE_MASQUE -> rows.sortedWith(compareBy { if (it.noteMoyenne == null) 1 else 0 }
+                              .thenByDescending { it.noteMoyenne ?: 0.0 }.thenWith(collator) { it.titre })
+    TriMode.NOTE_CONSEIL -> rows.sortedWith(compareBy { if (it.scoreHybride == null) 1 else 0 }
+                              .thenByDescending { it.scoreHybride ?: 0.0 }.thenWith(collator) { it.titre })
+}
+```
+
+### OnKindleUi — nouveau champ
+
+`app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt` :
+```kotlin
+val scoreHybride: Double? = null   // ajouté dans OnKindleUi
+```
+
+### UI — 2 lignes de chips
+
+`app/src/main/java/com/lmelp/mobile/ui/onkindle/OnKindleScreen.kt` :
+- Ligne 1 : `[Non lus] [Lus]`
+- Ligne 2 : `[a→z] [Note masque ↓] [Note conseil ↓]    [count]`
+
+Signature `OnKindleContent` : `onToggleTriParNote: () -> Unit` → `onSetTriMode: (TriMode) -> Unit`.
+
+## TDD
+
+`app/src/test/java/com/lmelp/mobile/OnKindleViewModelTest.kt` — tests mis à jour :
+- `fakeEntity(OnKindleEntity)` → `fakeRow(OnKindleAvecConseilRow)` avec param `scoreHybride: Double? = null`
+- Tous les `dao.getOnKindleFiltres(...)` → `dao.getOnKindleAvecConseil(...)`
+- Tous les `state.triParNote` → `state.triMode == TriMode.ALPHA/NOTE_MASQUE/NOTE_CONSEIL`
+- Nouveaux tests : `setTriMode NOTE_MASQUE`, `setTriMode NOTE_CONSEIL`, `scoreHybride propage dans OnKindleUi`
+
+## Pas de migration Room
+
+`OnKindleAvecConseilRow` est une data class de projection (comme `PalmaresFiltreAvecUrlRow`),
+pas une `@Entity`. Aucun changement de schéma, aucun incrément de version.
+
+## Donnée dans la DB
+
+19 livres en commun entre `onkindle` et `recommendations` (vérifiable via
+`SELECT COUNT(*) FROM onkindle ok JOIN recommendations r ON ok.livre_id = r.livre_id`).
+
+## Note technique sur sqlite3
+
+Pour accéder à la DB depuis le terminal :
+```bash
+source /workspaces/lmelp-mobile/.venv/bin/activate
+sqlite3 app/src/main/assets/lmelp.db "..."
+```
+(documenté dans CLAUDE.md section "Environnement local")


### PR DESCRIPTION
## Summary

- Remplace le booléen `triParNote` par l'enum `TriMode { ALPHA, NOTE_MASQUE, NOTE_CONSEIL }`
- Nouveau `LEFT JOIN onkindle ⟕ recommendations` dans `OnKindleDao` via `OnKindleAvecConseilRow` (data class de projection, sans migration Room)
- `scoreHybride` propagé jusqu'à `OnKindleUi`
- UI : 2 lignes de chips — filtres (Non lus / Lus) et tris (a→z / Note masque ↓ / Note conseil ↓)
- Les livres absents des recommandations (`scoreHybride = null`) sont triés en dernier

## Test plan

- [x] 3 nouveaux tests TDD (ALPHA, NOTE_MASQUE, NOTE_CONSEIL) + `scoreHybride` propagé
- [x] `fakeEntity(OnKindleEntity)` → `fakeRow(OnKindleAvecConseilRow)` dans tous les tests existants
- [x] `./gradlew testDebugUnitTest` — 9 tests passent
- [x] `./gradlew lint` — aucune erreur
- [x] CI/CD GitHub Actions : ✅

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)