### PR TITLE
feat(livre): badge Calibre lu/note + date lecture sur fiche livre, auteur, émission (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,20 @@
 
 Application Android pour consulter le contenu de Le Masque et la Plume (LMELP) — émission littéraire de France Inter — hors connexion.
 
-Un aperçu de sa page d'accueil :
+Et obtenir des recommandations de lectures personnalisées.
 
-![](img/screenshot_lmelp-mobile_small.png)
+![Aperçu de la page d'accueil](img/screenshot_lmelp-mobile_small.png)
 
-## pyfoundry-template
+## Projets associés
 
-Ce projet a été instancié depuis un template.
+Les projets associés sont :
 
-Toutes les infos sur ce template et la façon de l'utiliser sont dans sa [documentation](https://castorfou.github.io/PyFoundry/).
+- **[lmelp](https://github.com/castorfou/lmelp)** - pour telecharger les episodes radiophoniques (podcasts) du masque
+- **[back-office-lmelp](https://github.com/castorfou/back-office-lmelp)** - pour travailler le contenu de la base de données.
+- **[docker-lmelp](https://github.com/castorfou/docker-lmelp)** - pour héberger l'ensemble des composants dans une stack docker.
+- **[lmelp-pap](https://github.com/castorfou/lmelp-pap)** - le Projet d'Archivage Patrimoniale (1955-2016) des épisodes du Masque et la Plume.
+
+Tous ces projets sont basés sur le template de projet [PyFoundry](https://castorfou.github.io/PyFoundry/).
 
 
 ## Vision
@@ -111,67 +116,6 @@ python scripts/export_mongo_to_sqlite.py --verify app/src/main/assets/lmelp.db
 ./gradlew installDebug
 ```
 
-## Installation
-
-Ce projet utilise **uv** pour la gestion des dépendances et des environnements Python.
-
-# Créer un tag → déclenche GitHub Actions → build APK + release
-git tag v1.0.0
-git push origin v1.0.0
-```
-
-GitHub Actions va :
-1. Exporter MongoDB → SQLite (si secrets configurés)
-2. Builder l'APK signé
-3. Publier dans GitHub Releases
-
-Voir [docs/ci-cd.md](docs/ci-cd.md) pour la configuration.
-
-### Avec VS Code + Devcontainer (Recommandé)
-
-Si vous avez Docker et VS Code :
-
-```bash
-# 1. Authentifiez-vous à ghcr.io (si nécessaire)
-# Créez un Personal Access Token : https://github.com/settings/tokens/new
-# Permissions : read:packages
-docker login ghcr.io -u VOTRE_USERNAME
-
-# 2. Ouvrez dans VS Code
-code .
-# VS Code proposera "Reopen in Container"
-```
-
-## Structure du projet
-
-```
-├── app/                          # Application Android (Kotlin)
-│   ├── src/main/
-│   │   ├── assets/lmelp.db       # Base SQLite embarquée (générée)
-│   │   ├── java/com/lmelp/mobile/
-│   │   │   ├── data/             # Room entities, DAOs, Database
-│   │   │   ├── ui/               # Composables Jetpack Compose
-│   │   │   │   ├── emissions/
-│   │   │   │   ├── palmares/
-│   │   │   │   ├── critiques/
-│   │   │   │   ├── search/
-│   │   │   │   └── recommendations/
-│   │   │   ├── viewmodel/        # ViewModels
-│   │   │   └── MainActivity.kt
-│   │   └── res/
-│   └── build.gradle.kts
-├── scripts/
-│   └── export_mongo_to_sqlite.py # Export MongoDB → SQLite
-├── docs/
-│   ├── architecture.md           # Architecture détaillée
-│   ├── data-schema.md            # Schéma SQLite
-│   └── ci-cd.md                  # Pipeline CI/CD
-├── .github/workflows/
-│   └── release.yml               # Build + publish APK
-├── pyproject.toml                # Dépendances Python (script export)
-├── CLAUDE.md                     # Guide pour Claude Code
-└── README.md
-```
 
 
 ## Source des données
@@ -182,55 +126,3 @@ Les données proviennent du projet [back-office-lmelp](https://github.com/castor
 - **1114 auteurs**
 - **25 critiques**
 - **4100+ avis** avec notes (1-10)
-
-
-## Documentation
-
-📚 La documentation complète est disponible sur [castorfou.github.io/lmelp-mobile](https://castorfou.github.io/lmelp-mobile)
-
-### Activer GitHub Pages (première fois)
-
-Pour déployer la documentation, activez GitHub Pages :
-
-```bash
-# Via gh CLI (recommandé)
-gh api repos/castorfou/lmelp-mobile/pages \
-  -X POST \
-  -f build_type=workflow
-
-# Ou manuellement :
-# 1. Allez dans Settings > Pages
-# 2. Source : sélectionnez "GitHub Actions"
-```
-
-### Générer localement
-
-```bash
-# Installer les dépendances de documentation
-uv sync --extra docs
-
-# Prévisualiser localement
-uv run mkdocs serve
-
-# La documentation sera accessible à l'URL affichée dans les logs
-# Example: http://127.0.0.1:8000/lmelp-mobile/
-```
-
-!!! note "URL locale"
-    Comme `site_url` est configuré pour GitHub Pages avec un chemin de base,
-    MkDocs servira la documentation avec ce même chemin en local.
-    Accédez à l'URL complète affichée dans les logs (avec le chemin `/lmelp-mobile/`).
-
-    Si vous souhaitez servir sans chemin de base pour le développement local,
-    commentez temporairement la ligne `site_url` dans `mkdocs.yml`.
-
-## Usage
-
-Décrivez ici comment utiliser votre projet.
-
-## Contribution
-
-1. Installez les hooks pre-commit : `pre-commit install`
-2. Créez une branche pour votre fonctionnalité
-3. Commitez vos changements
-4. Ouvrez une Pull Request

--- a/app/src/main/java/com/lmelp/mobile/data/db/AuteursDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/AuteursDao.kt
@@ -5,12 +5,15 @@ import androidx.room.Dao
 import androidx.room.Query
 import com.lmelp.mobile.data.model.AuteurEntity
 
-/** Livre d'un auteur avec note moyenne (depuis palmares) et date de dernière émission. */
+/** Livre d'un auteur avec note moyenne (depuis palmares), date de dernière émission et données Calibre. */
 data class LivreParAuteurRow(
     @ColumnInfo(name = "livre_id") val livreId: String,
     val titre: String,
     @ColumnInfo(name = "note_moyenne") val noteMoyenne: Double?,
-    @ColumnInfo(name = "derniere_emission_date") val derniereEmissionDate: String?
+    @ColumnInfo(name = "derniere_emission_date") val derniereEmissionDate: String?,
+    @ColumnInfo(name = "calibre_in_library", defaultValue = "0") val calibreInLibrary: Int = 0,
+    @ColumnInfo(name = "calibre_lu", defaultValue = "0") val calibreLu: Int = 0,
+    @ColumnInfo(name = "calibre_rating") val calibreRating: Double? = null
 )
 
 @Dao
@@ -22,7 +25,10 @@ interface AuteursDao {
     @Query("""
         SELECT l.id as livre_id, l.titre,
                p.note_moyenne,
-               MAX(em.date) as derniere_emission_date
+               MAX(em.date) as derniere_emission_date,
+               COALESCE(p.calibre_in_library, 0) as calibre_in_library,
+               COALESCE(p.calibre_lu, 0) as calibre_lu,
+               p.calibre_rating
         FROM livres l
         LEFT JOIN palmares p ON p.livre_id = l.id
         LEFT JOIN avis a ON a.livre_id = l.id

--- a/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
@@ -34,7 +34,8 @@ data class LivreAvecCalibreRow(
     @ColumnInfo(name = "updated_at") val updatedAt: String?,
     @ColumnInfo(name = "calibre_in_library", defaultValue = "0") val calibreInLibrary: Int = 0,
     @ColumnInfo(name = "calibre_lu", defaultValue = "0") val calibreLu: Int = 0,
-    @ColumnInfo(name = "calibre_rating") val calibreRating: Double? = null
+    @ColumnInfo(name = "calibre_rating") val calibreRating: Double? = null,
+    @ColumnInfo(name = "date_lecture") val dateLecture: String? = null
 )
 
 @Dao
@@ -48,7 +49,8 @@ interface LivresDao {
                l.url_babelio, l.url_cover, l.created_at, l.updated_at,
                COALESCE(p.calibre_in_library, 0) as calibre_in_library,
                COALESCE(p.calibre_lu, 0) as calibre_lu,
-               p.calibre_rating
+               p.calibre_rating,
+               p.date_lecture
         FROM livres l
         LEFT JOIN palmares p ON p.livre_id = l.id
         WHERE l.id = :id

--- a/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
@@ -21,6 +21,22 @@ data class AvisAvecEmissionRow(
     @ColumnInfo(name = "emission_date") val emissionDate: String?
 )
 
+/** Livre enrichi avec les données Calibre depuis la table palmares (LEFT JOIN). */
+data class LivreAvecCalibreRow(
+    val id: String,
+    val titre: String,
+    @ColumnInfo(name = "auteur_id") val auteurId: String?,
+    @ColumnInfo(name = "auteur_nom") val auteurNom: String?,
+    val editeur: String?,
+    @ColumnInfo(name = "url_babelio") val urlBabelio: String?,
+    @ColumnInfo(name = "url_cover") val urlCover: String?,
+    @ColumnInfo(name = "created_at") val createdAt: String?,
+    @ColumnInfo(name = "updated_at") val updatedAt: String?,
+    @ColumnInfo(name = "calibre_in_library", defaultValue = "0") val calibreInLibrary: Int = 0,
+    @ColumnInfo(name = "calibre_lu", defaultValue = "0") val calibreLu: Int = 0,
+    @ColumnInfo(name = "calibre_rating") val calibreRating: Double? = null
+)
+
 @Dao
 interface LivresDao {
 
@@ -28,11 +44,36 @@ interface LivresDao {
     suspend fun getLivreById(id: String): LivreEntity?
 
     @Query("""
+        SELECT l.id, l.titre, l.auteur_id, l.auteur_nom, l.editeur,
+               l.url_babelio, l.url_cover, l.created_at, l.updated_at,
+               COALESCE(p.calibre_in_library, 0) as calibre_in_library,
+               COALESCE(p.calibre_lu, 0) as calibre_lu,
+               p.calibre_rating
+        FROM livres l
+        LEFT JOIN palmares p ON p.livre_id = l.id
+        WHERE l.id = :id
+    """)
+    suspend fun getLivreAvecCalibreById(id: String): LivreAvecCalibreRow?
+
+    @Query("""
         SELECT l.* FROM livres l
         JOIN emission_livres el ON el.livre_id = l.id
         WHERE el.emission_id = :emissionId
     """)
     suspend fun getLivresByEmission(emissionId: String): List<LivreEntity>
+
+    @Query("""
+        SELECT l.id, l.titre, l.auteur_id, l.auteur_nom, l.editeur,
+               l.url_babelio, l.url_cover, l.created_at, l.updated_at,
+               COALESCE(p.calibre_in_library, 0) as calibre_in_library,
+               COALESCE(p.calibre_lu, 0) as calibre_lu,
+               p.calibre_rating
+        FROM livres l
+        JOIN emission_livres el ON el.livre_id = l.id
+        LEFT JOIN palmares p ON p.livre_id = l.id
+        WHERE el.emission_id = :emissionId
+    """)
+    suspend fun getLivresAvecCalibreByEmission(emissionId: String): List<LivreAvecCalibreRow>
 
     @Query("SELECT * FROM avis WHERE livre_id = :livreId ORDER BY created_at DESC")
     suspend fun getAvisByLivre(livreId: String): List<AvisEntity>

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -60,7 +60,8 @@ data class LivreDetailUi(
     val avisParEmission: List<AvisParEmissionUi>,
     val calibreInLibrary: Boolean = false,
     val calibreLu: Boolean = false,
-    val calibreRating: Double? = null
+    val calibreRating: Double? = null,
+    val dateLecture: String? = null
 )
 
 data class PalmaresUi(

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -27,7 +27,10 @@ data class LivreUi(
     val editeur: String?,
     val noteMoyenne: Double? = null,
     val section: String? = null,
-    val urlCover: String? = null
+    val urlCover: String? = null,
+    val calibreInLibrary: Boolean = false,
+    val calibreLu: Boolean = false,
+    val calibreRating: Double? = null
 )
 
 data class AvisUi(
@@ -54,7 +57,10 @@ data class LivreDetailUi(
     val urlBabelio: String?,
     val urlCover: String?,
     val noteMoyenne: Double?,
-    val avisParEmission: List<AvisParEmissionUi>
+    val avisParEmission: List<AvisParEmissionUi>,
+    val calibreInLibrary: Boolean = false,
+    val calibreLu: Boolean = false,
+    val calibreRating: Double? = null
 )
 
 data class PalmaresUi(
@@ -100,7 +106,10 @@ data class LivreParAuteurUi(
     val livreId: String,
     val titre: String,
     val noteMoyenne: Double?,
-    val derniereEmissionDate: String?
+    val derniereEmissionDate: String?,
+    val calibreInLibrary: Boolean = false,
+    val calibreLu: Boolean = false,
+    val calibreRating: Double? = null
 )
 
 data class AuteurDetailUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt
@@ -19,7 +19,10 @@ class AuteursRepository(
                     livreId = row.livreId,
                     titre = row.titre,
                     noteMoyenne = row.noteMoyenne,
-                    derniereEmissionDate = row.derniereEmissionDate
+                    derniereEmissionDate = row.derniereEmissionDate,
+                    calibreInLibrary = row.calibreInLibrary == 1,
+                    calibreLu = row.calibreLu == 1,
+                    calibreRating = row.calibreRating
                 )
             }
 

--- a/app/src/main/java/com/lmelp/mobile/data/repository/EmissionsRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/EmissionsRepository.kt
@@ -36,11 +36,16 @@ class EmissionsRepository(
         val episode = episodesDao.getEpisodeById(emission.episodeId)
         val notesMap = livresDao.getNotesParLivreForEmission(emissionId)
             .associate { it.livreId to Pair(it.avgNote, it.section) }
-        val livres = livresDao.getLivresByEmission(emissionId).map {
+        val livres = livresDao.getLivresAvecCalibreByEmission(emissionId).map {
             val (note, section) = notesMap[it.id] ?: Pair(null, null)
-            LivreUi(id = it.id, titre = it.titre, auteurNom = it.auteurNom,
+            LivreUi(
+                id = it.id, titre = it.titre, auteurNom = it.auteurNom,
                 editeur = it.editeur, noteMoyenne = note, section = section,
-                urlCover = it.urlCover)
+                urlCover = it.urlCover,
+                calibreInLibrary = it.calibreInLibrary == 1,
+                calibreLu = it.calibreLu == 1,
+                calibreRating = it.calibreRating
+            )
         }
         val avisCritiques = avisCritiquesDao.getByEmissionId(emissionId)
         return EmissionDetailUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
@@ -10,7 +10,7 @@ class LivresRepository(
 ) {
 
     suspend fun getLivreDetail(livreId: String): LivreDetailUi? {
-        val livre = livresDao.getLivreById(livreId) ?: return null
+        val livre = livresDao.getLivreAvecCalibreById(livreId) ?: return null
         val rows = livresDao.getAvisAvecEmissionByLivre(livreId)
 
         val noteMoyenne = rows.mapNotNull { it.avis.note }
@@ -51,7 +51,10 @@ class LivresRepository(
             urlBabelio = livre.urlBabelio,
             urlCover = livre.urlCover,
             noteMoyenne = noteMoyenne,
-            avisParEmission = avisParEmission
+            avisParEmission = avisParEmission,
+            calibreInLibrary = livre.calibreInLibrary == 1,
+            calibreLu = livre.calibreLu == 1,
+            calibreRating = livre.calibreRating
         )
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
@@ -54,7 +54,8 @@ class LivresRepository(
             avisParEmission = avisParEmission,
             calibreInLibrary = livre.calibreInLibrary == 1,
             calibreLu = livre.calibreLu == 1,
-            calibreRating = livre.calibreRating
+            calibreRating = livre.calibreRating,
+            dateLecture = livre.dateLecture
         )
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.lmelp.mobile.data.model.LivreParAuteurUi
 import com.lmelp.mobile.data.repository.AuteursRepository
+import com.lmelp.mobile.ui.components.CalibreBadge
 import com.lmelp.mobile.ui.components.EmptyState
 import com.lmelp.mobile.ui.components.ErrorMessage
 import com.lmelp.mobile.ui.components.LoadingIndicator
@@ -111,9 +112,14 @@ fun LivreParAuteurCard(livre: LivreParAuteurUi, onClick: () -> Unit) {
                     )
                 }
             }
-            livre.noteMoyenne?.let {
-                NoteBadge(
-                    note = it,
+            Column(horizontalAlignment = Alignment.End) {
+                livre.noteMoyenne?.let {
+                    NoteBadge(note = it)
+                }
+                CalibreBadge(
+                    calibreInLibrary = livre.calibreInLibrary,
+                    calibreLu = livre.calibreLu,
+                    calibreRating = livre.calibreRating,
                     modifier = Modifier.padding(start = 8.dp)
                 )
             }

--- a/app/src/main/java/com/lmelp/mobile/ui/components/CommonComponents.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/components/CommonComponents.kt
@@ -2,6 +2,7 @@ package com.lmelp.mobile.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -9,11 +10,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
@@ -78,6 +81,37 @@ fun BookCoverThumbnail(
         )
     } else {
         Spacer(modifier = modifier.width(width).height(height))
+    }
+}
+
+/**
+ * Badge Calibre : affiche ✓ (vert) si lu, ◯ (gris) si dans la bibliothèque mais non lu,
+ * et la note personnelle (X/10) si le livre est lu et noté.
+ * N'affiche rien si le livre n'est pas dans la bibliothèque Calibre.
+ */
+@Composable
+fun CalibreBadge(
+    calibreInLibrary: Boolean,
+    calibreLu: Boolean,
+    calibreRating: Double?,
+    modifier: Modifier = Modifier
+) {
+    if (!calibreInLibrary) return
+    Column(modifier = modifier, horizontalAlignment = Alignment.End) {
+        Text(
+            text = if (calibreLu) "✓" else "◯",
+            style = MaterialTheme.typography.bodyMedium,
+            color = if (calibreLu) Color(0xFF2E7D32) else Color.Gray
+        )
+        if (calibreLu) {
+            calibreRating?.let {
+                Text(
+                    text = "${it.toInt()}/10",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color(0xFF2E7D32)
+                )
+            }
+        }
     }
 }
 

--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/EmissionDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/EmissionDetailScreen.kt
@@ -38,6 +38,7 @@ import com.lmelp.mobile.data.model.EmissionDetailUi
 import com.lmelp.mobile.data.model.LivreUi
 import com.lmelp.mobile.data.repository.EmissionsRepository
 import com.lmelp.mobile.ui.components.BookCoverThumbnail
+import com.lmelp.mobile.ui.components.CalibreBadge
 import com.lmelp.mobile.ui.components.ErrorMessage
 import com.lmelp.mobile.ui.components.LoadingIndicator
 import com.lmelp.mobile.ui.components.NoteBadge
@@ -213,7 +214,15 @@ fun LivreCard(livre: LivreUi, onClick: () -> Unit) {
                 Text(text = livre.titre, style = MaterialTheme.typography.titleSmall)
                 livre.auteurNom?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
             }
-            livre.noteMoyenne?.let { NoteBadge(note = it) }
+            Column(horizontalAlignment = Alignment.End) {
+                livre.noteMoyenne?.let { NoteBadge(note = it) }
+                CalibreBadge(
+                    calibreInLibrary = livre.calibreInLibrary,
+                    calibreLu = livre.calibreLu,
+                    calibreRating = livre.calibreRating,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
@@ -48,6 +48,7 @@ import com.lmelp.mobile.data.model.AvisParEmissionUi
 import com.lmelp.mobile.data.model.AvisUi
 import com.lmelp.mobile.data.model.LivreDetailUi
 import com.lmelp.mobile.data.repository.LivresRepository
+import com.lmelp.mobile.ui.components.CalibreBadge
 import com.lmelp.mobile.ui.components.EmptyState
 import com.lmelp.mobile.ui.components.ErrorMessage
 import com.lmelp.mobile.ui.components.LoadingIndicator
@@ -169,8 +170,16 @@ fun LivreDetailContent(
                         )
                     }
                 }
-                livre.noteMoyenne?.let {
-                    NoteBadge(note = it, fontSize = 32.sp, modifier = Modifier.padding(start = 8.dp))
+                Column(horizontalAlignment = Alignment.End) {
+                    livre.noteMoyenne?.let {
+                        NoteBadge(note = it, fontSize = 32.sp)
+                    }
+                    CalibreBadge(
+                        calibreInLibrary = livre.calibreInLibrary,
+                        calibreLu = livre.calibreLu,
+                        calibreRating = livre.calibreRating,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
@@ -169,6 +169,14 @@ fun LivreDetailContent(
                             modifier = Modifier.padding(top = 4.dp)
                         )
                     }
+                    if (livre.calibreLu && livre.dateLecture != null) {
+                        Text(
+                            text = "Lu le ${formatDateLong(livre.dateLecture)}",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = androidx.compose.ui.graphics.Color(0xFF2E7D32),
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
                 }
                 Column(horizontalAlignment = Alignment.End) {
                     livre.noteMoyenne?.let {

--- a/app/src/test/java/com/lmelp/mobile/CalibreBadgeRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/CalibreBadgeRepositoryTest.kt
@@ -42,7 +42,8 @@ class CalibreBadgeRepositoryTest {
         id: String,
         calibreInLibrary: Int = 0,
         calibreLu: Int = 0,
-        calibreRating: Double? = null
+        calibreRating: Double? = null,
+        dateLecture: String? = null
     ) = LivreAvecCalibreRow(
         id = id,
         titre = "Titre $id",
@@ -55,7 +56,8 @@ class CalibreBadgeRepositoryTest {
         updatedAt = null,
         calibreInLibrary = calibreInLibrary,
         calibreLu = calibreLu,
-        calibreRating = calibreRating
+        calibreRating = calibreRating,
+        dateLecture = dateLecture
     )
 
     private fun makeAuteurEntity(id: String) = AuteurEntity(id = id, nom = "Auteur", urlBabelio = null)
@@ -123,6 +125,34 @@ class CalibreBadgeRepositoryTest {
         assertTrue(result.calibreInLibrary)
         assertFalse(result.calibreLu)
         assertNull(result.calibreRating)
+    }
+
+    @Test
+    fun `LivreDetailUi dateLecture propagee quand livre lu avec date`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibre("l1", calibreInLibrary = 1, calibreLu = 1, dateLecture = "2024-03-15")
+        )
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList())
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")!!
+
+        assertEquals("2024-03-15", result.dateLecture)
+    }
+
+    @Test
+    fun `LivreDetailUi dateLecture est null quand non disponible`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibre("l1", calibreInLibrary = 1, calibreLu = 1, dateLecture = null)
+        )
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList())
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")!!
+
+        assertNull(result.dateLecture)
     }
 
     @Test

--- a/app/src/test/java/com/lmelp/mobile/CalibreBadgeRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/CalibreBadgeRepositoryTest.kt
@@ -1,0 +1,174 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.AvisAvecEmissionRow
+import com.lmelp.mobile.data.db.AuteursDao
+import com.lmelp.mobile.data.db.LivreAvecCalibreRow
+import com.lmelp.mobile.data.db.LivreParAuteurRow
+import com.lmelp.mobile.data.db.LivresDao
+import com.lmelp.mobile.data.model.AvisEntity
+import com.lmelp.mobile.data.model.AuteurEntity
+import com.lmelp.mobile.data.repository.AuteursRepository
+import com.lmelp.mobile.data.repository.LivresRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests TDD pour la propagation des champs Calibre (calibre_lu, calibre_in_library, calibre_rating)
+ * dans les repositories liés aux livres (issue #84).
+ */
+class CalibreBadgeRepositoryTest {
+
+    // --- Helpers ---
+
+    private fun makeAvisRow(emissionId: String, livreId: String) = AvisAvecEmissionRow(
+        avis = AvisEntity(
+            id = "a1", emissionId = emissionId, livreId = livreId,
+            critiqueId = "c1", note = 7.0, commentaire = null,
+            livreTitre = null, auteurNom = null, critiqueNom = "Critique",
+            matchPhase = null, section = null, createdAt = null
+        ),
+        emissionTitre = "Emission test",
+        emissionDate = "2024-01-01"
+    )
+
+    private fun makeLivreAvecCalibre(
+        id: String,
+        calibreInLibrary: Int = 0,
+        calibreLu: Int = 0,
+        calibreRating: Double? = null
+    ) = LivreAvecCalibreRow(
+        id = id,
+        titre = "Titre $id",
+        auteurId = null,
+        auteurNom = "Auteur",
+        editeur = null,
+        urlBabelio = null,
+        urlCover = null,
+        createdAt = null,
+        updatedAt = null,
+        calibreInLibrary = calibreInLibrary,
+        calibreLu = calibreLu,
+        calibreRating = calibreRating
+    )
+
+    private fun makeAuteurEntity(id: String) = AuteurEntity(id = id, nom = "Auteur", urlBabelio = null)
+
+    private fun makeLivreParAuteurRow(
+        livreId: String,
+        calibreInLibrary: Int = 0,
+        calibreLu: Int = 0,
+        calibreRating: Double? = null
+    ) = LivreParAuteurRow(
+        livreId = livreId,
+        titre = "Titre $livreId",
+        noteMoyenne = null,
+        derniereEmissionDate = "2024-01-01",
+        calibreInLibrary = calibreInLibrary,
+        calibreLu = calibreLu,
+        calibreRating = calibreRating
+    )
+
+    // --- LivresRepository ---
+
+    @Test
+    fun `LivreDetailUi calibre fields true when livre lu dans Calibre`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibre("l1", calibreInLibrary = 1, calibreLu = 1, calibreRating = 8.0)
+        )
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(listOf(makeAvisRow("e1", "l1")))
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")!!
+
+        assertTrue(result.calibreInLibrary)
+        assertTrue(result.calibreLu)
+        assertEquals(8.0, result.calibreRating!!, 0.001)
+    }
+
+    @Test
+    fun `LivreDetailUi calibre fields false when livre not in Calibre`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibre("l1", calibreInLibrary = 0, calibreLu = 0, calibreRating = null)
+        )
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList())
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")!!
+
+        assertFalse(result.calibreInLibrary)
+        assertFalse(result.calibreLu)
+        assertNull(result.calibreRating)
+    }
+
+    @Test
+    fun `LivreDetailUi calibreInLibrary true but calibreLu false when in library not read`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibre("l1", calibreInLibrary = 1, calibreLu = 0, calibreRating = null)
+        )
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList())
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")!!
+
+        assertTrue(result.calibreInLibrary)
+        assertFalse(result.calibreLu)
+        assertNull(result.calibreRating)
+    }
+
+    @Test
+    fun `LivreDetailUi returns null when livre not found`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(null)
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("inexistant")
+
+        assertNull(result)
+    }
+
+    // --- AuteursRepository ---
+
+    @Test
+    fun `LivreParAuteurUi calibreLu true when livre lu dans Calibre`() = runTest {
+        val dao = mock<AuteursDao>()
+        whenever(dao.getAuteurById(any())).thenReturn(makeAuteurEntity("a1"))
+        whenever(dao.getLivresParAuteur(any())).thenReturn(
+            listOf(makeLivreParAuteurRow("l1", calibreInLibrary = 1, calibreLu = 1, calibreRating = 7.5))
+        )
+
+        val repo = AuteursRepository(dao)
+        val result = repo.getAuteurDetail("a1")!!
+
+        val livre = result.livres[0]
+        assertTrue(livre.calibreInLibrary)
+        assertTrue(livre.calibreLu)
+        assertEquals(7.5, livre.calibreRating!!, 0.001)
+    }
+
+    @Test
+    fun `LivreParAuteurUi calibre fields false when not in Calibre`() = runTest {
+        val dao = mock<AuteursDao>()
+        whenever(dao.getAuteurById(any())).thenReturn(makeAuteurEntity("a1"))
+        whenever(dao.getLivresParAuteur(any())).thenReturn(
+            listOf(makeLivreParAuteurRow("l1", calibreInLibrary = 0, calibreLu = 0))
+        )
+
+        val repo = AuteursRepository(dao)
+        val result = repo.getAuteurDetail("a1")!!
+
+        val livre = result.livres[0]
+        assertFalse(livre.calibreInLibrary)
+        assertFalse(livre.calibreLu)
+        assertNull(livre.calibreRating)
+    }
+}

--- a/app/src/test/java/com/lmelp/mobile/LivresRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/LivresRepositoryTest.kt
@@ -1,9 +1,9 @@
 package com.lmelp.mobile
 
 import com.lmelp.mobile.data.db.AvisAvecEmissionRow
+import com.lmelp.mobile.data.db.LivreAvecCalibreRow
 import com.lmelp.mobile.data.db.LivresDao
 import com.lmelp.mobile.data.model.AvisEntity
-import com.lmelp.mobile.data.model.LivreEntity
 import com.lmelp.mobile.data.repository.LivresRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -36,14 +36,14 @@ class LivresRepositoryTest {
         createdAt = null
     )
 
-    private fun makeLivreEntity(id: String) = LivreEntity(
+    private fun makeLivreAvecCalibreRow(id: String, urlCover: String? = null) = LivreAvecCalibreRow(
         id = id,
         titre = "Titre $id",
         auteurId = null,
         auteurNom = "Auteur",
         editeur = null,
         urlBabelio = null,
-        urlCover = null,
+        urlCover = urlCover,
         createdAt = null,
         updatedAt = null
     )
@@ -51,7 +51,7 @@ class LivresRepositoryTest {
     @Test
     fun `noteMoyenne calculee comme moyenne des notes non nulles`() = runTest {
         val dao = mock<LivresDao>()
-        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(makeLivreAvecCalibreRow("l1"))
         whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
             listOf(
                 AvisAvecEmissionRow(makeAvisEntity("a1", "e1", "l1", "Zola", 8.0), "Emission 1", "2023-01-10"),
@@ -70,7 +70,7 @@ class LivresRepositoryTest {
     @Test
     fun `noteMoyenne est null si aucun avis na de note`() = runTest {
         val dao = mock<LivresDao>()
-        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(makeLivreAvecCalibreRow("l1"))
         whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
             listOf(
                 AvisAvecEmissionRow(makeAvisEntity("a1", "e1", "l1", "Zola", null), "Emission 1", "2023-01-10"),
@@ -86,7 +86,7 @@ class LivresRepositoryTest {
     @Test
     fun `avis regroupes par emission dans l ordre chronologique inverse`() = runTest {
         val dao = mock<LivresDao>()
-        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(makeLivreAvecCalibreRow("l1"))
         // e2 est plus récente (2024), e1 est plus ancienne (2023)
         whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
             listOf(
@@ -105,10 +105,11 @@ class LivresRepositoryTest {
     }
 
     @Test
-    fun `urlCover est propagee depuis LivreEntity`() = runTest {
+    fun `urlCover est propagee depuis LivreAvecCalibreRow`() = runTest {
         val dao = mock<LivresDao>()
-        val livreAvecCover = makeLivreEntity("l1").copy(urlCover = "https://example.com/cover.jpg")
-        whenever(dao.getLivreById(any())).thenReturn(livreAvecCover)
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibreRow("l1", urlCover = "https://example.com/cover.jpg")
+        )
         whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList())
 
         val repo = LivresRepository(dao)
@@ -118,9 +119,9 @@ class LivresRepositoryTest {
     }
 
     @Test
-    fun `urlCover est null si LivreEntity na pas de cover`() = runTest {
+    fun `urlCover est null si row na pas de cover`() = runTest {
         val dao = mock<LivresDao>()
-        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(makeLivreAvecCalibreRow("l1"))
         whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList())
 
         val repo = LivresRepository(dao)
@@ -132,7 +133,7 @@ class LivresRepositoryTest {
     @Test
     fun `avis tries par critique alphabetique dans chaque groupe`() = runTest {
         val dao = mock<LivresDao>()
-        whenever(dao.getLivreById(any())).thenReturn(makeLivreEntity("l1"))
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(makeLivreAvecCalibreRow("l1"))
         whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(
             listOf(
                 AvisAvecEmissionRow(makeAvisEntity("a1", "e1", "l1", "Zola", 8.0), "Emission 1", "2023-01-10"),

--- a/app/src/test/java/com/lmelp/mobile/UrlCoverPropagationTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/UrlCoverPropagationTest.kt
@@ -1,7 +1,7 @@
 package com.lmelp.mobile
 
+import com.lmelp.mobile.data.db.LivreAvecCalibreRow
 import com.lmelp.mobile.data.db.LivresDao
-import com.lmelp.mobile.data.model.LivreEntity
 import com.lmelp.mobile.data.repository.EmissionsRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
@@ -17,12 +17,12 @@ import com.lmelp.mobile.data.model.EmissionEntity
 import com.lmelp.mobile.data.model.EpisodeEntity
 
 /**
- * Tests RED → vérifie que urlCover est propagé depuis LivreEntity vers LivreUi
- * dans EmissionsRepository (et par extension dans PalmaresUi, RecommendationUi, SearchResultUi).
+ * Tests RED → vérifie que urlCover est propagé depuis LivreAvecCalibreRow vers LivreUi
+ * dans EmissionsRepository.
  */
 class UrlCoverPropagationTest {
 
-    private fun makeLivreEntity(id: String, urlCover: String? = null) = LivreEntity(
+    private fun makeLivreAvecCalibreRow(id: String, urlCover: String? = null) = LivreAvecCalibreRow(
         id = id,
         titre = "Titre $id",
         auteurId = null,
@@ -65,8 +65,8 @@ class UrlCoverPropagationTest {
         whenever(emissionsDao.getEmissionById(any())).thenReturn(makeEmissionEntity("e1"))
         whenever(episodesDao.getEpisodeById(any())).thenReturn(makeEpisodeEntity())
         whenever(livresDao.getNotesParLivreForEmission(any())).thenReturn(emptyList())
-        whenever(livresDao.getLivresByEmission(any())).thenReturn(
-            listOf(makeLivreEntity("l1", urlCover = "https://example.com/cover.jpg"))
+        whenever(livresDao.getLivresAvecCalibreByEmission(any())).thenReturn(
+            listOf(makeLivreAvecCalibreRow("l1", urlCover = "https://example.com/cover.jpg"))
         )
         whenever(avisCritiquesDao.getByEmissionId(any())).thenReturn(null)
 
@@ -86,8 +86,8 @@ class UrlCoverPropagationTest {
         whenever(emissionsDao.getEmissionById(any())).thenReturn(makeEmissionEntity("e1"))
         whenever(episodesDao.getEpisodeById(any())).thenReturn(makeEpisodeEntity())
         whenever(livresDao.getNotesParLivreForEmission(any())).thenReturn(emptyList())
-        whenever(livresDao.getLivresByEmission(any())).thenReturn(
-            listOf(makeLivreEntity("l1", urlCover = null))
+        whenever(livresDao.getLivresAvecCalibreByEmission(any())).thenReturn(
+            listOf(makeLivreAvecCalibreRow("l1", urlCover = null))
         )
         whenever(avisCritiquesDao.getByEmissionId(any())).thenReturn(null)
 

--- a/docs/claude/memory/260409-1642-issue84-calibre-badge-fiche-auteur-emission.md
+++ b/docs/claude/memory/260409-1642-issue84-calibre-badge-fiche-auteur-emission.md
@@ -1,0 +1,82 @@
+# Issue #84 — Badge Calibre (lu + note) sur fiche livre, page auteur, page émission
+
+## Problème résolu
+
+Les données Calibre (`calibre_lu`, `calibre_in_library`, `calibre_rating`) existaient dans la table `palmares` mais ne remontaient pas dans les écrans fiche livre, page auteur et page émission. Seul le palmarès les affichait.
+
+## Fichiers modifiés
+
+### Couche données (DAOs)
+
+**`app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt`**
+- Nouvelle data class `LivreAvecCalibreRow` : contient tous les champs de `LivreEntity` + `calibre_in_library`, `calibre_lu`, `calibre_rating` (LEFT JOIN palmares)
+- Nouvelle méthode `getLivreAvecCalibreById(id)` → remplace `getLivreById` dans `LivresRepository`
+- Nouvelle méthode `getLivresAvecCalibreByEmission(emissionId)` → remplace `getLivresByEmission` dans `EmissionsRepository`
+
+**`app/src/main/java/com/lmelp/mobile/data/db/AuteursDao.kt`**
+- `LivreParAuteurRow` enrichi : ajout de `calibreInLibrary`, `calibreLu`, `calibreRating` (défaut 0/null)
+- `getLivresParAuteur` : requête SQL enrichie avec `COALESCE(p.calibre_in_library, 0)`, `COALESCE(p.calibre_lu, 0)`, `p.calibre_rating`
+
+### Couche données (modèles UI)
+
+**`app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt`**
+- `LivreDetailUi` : ajout `calibreInLibrary: Boolean = false`, `calibreLu: Boolean = false`, `calibreRating: Double? = null`
+- `LivreUi` : mêmes ajouts
+- `LivreParAuteurUi` : mêmes ajouts
+
+### Couche données (repositories)
+
+**`app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt`**
+- Utilise `getLivreAvecCalibreById` au lieu de `getLivreById`
+- Mappe `calibreInLibrary = livre.calibreInLibrary == 1`, `calibreLu = livre.calibreLu == 1`, `calibreRating = livre.calibreRating`
+
+**`app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt`**
+- Mappe les 3 champs calibre de `LivreParAuteurRow` vers `LivreParAuteurUi`
+
+**`app/src/main/java/com/lmelp/mobile/data/repository/EmissionsRepository.kt`**
+- Utilise `getLivresAvecCalibreByEmission` au lieu de `getLivresByEmission`
+- Mappe les 3 champs calibre vers `LivreUi`
+
+### Couche UI
+
+**`app/src/main/java/com/lmelp/mobile/ui/components/CommonComponents.kt`**
+- Nouveau composable réutilisable `CalibreBadge(calibreInLibrary, calibreLu, calibreRating, modifier)`
+- N'affiche rien si `!calibreInLibrary`
+- ✓ vert (#2E7D32) si lu, ◯ gris sinon, et `X/10` en dessous si noté
+
+**`app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt`**
+- `CalibreBadge` ajouté dans l'en-tête (colonne à droite, sous la `NoteBadge` note critique)
+
+**`app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt`**
+- `CalibreBadge` ajouté dans `LivreParAuteurCard` (colonne à droite, sous `NoteBadge`)
+
+**`app/src/main/java/com/lmelp/mobile/ui/emissions/EmissionDetailScreen.kt`**
+- `CalibreBadge` ajouté dans `LivreCard` (colonne à droite, sous `NoteBadge`)
+
+### Tests
+
+**`app/src/test/java/com/lmelp/mobile/CalibreBadgeRepositoryTest.kt`** (nouveau)
+- `LivresRepository` : calibreLu/calibreInLibrary/calibreRating correctement mappés (3 cas : lu, non lu, dans bibliothèque mais non lu)
+- `AuteursRepository` : propagation calibre dans `LivreParAuteurUi`
+
+**`app/src/test/java/com/lmelp/mobile/LivresRepositoryTest.kt`** (mis à jour)
+- Remplace `getLivreById` par `getLivreAvecCalibreById` dans les mocks
+
+**`app/src/test/java/com/lmelp/mobile/UrlCoverPropagationTest.kt`** (mis à jour)
+- Remplace `getLivresByEmission` par `getLivresAvecCalibreByEmission` dans les mocks
+
+## Pattern de conversion Int → Boolean
+
+Les champs SQLite `calibre_in_library` et `calibre_lu` sont des INTEGER (0/1). La conversion se fait dans les repositories :
+```
+calibreInLibrary = row.calibreInLibrary == 1
+calibreLu = row.calibreLu == 1
+```
+Les data classes Room utilisent `Int` avec `defaultValue = "0"`.
+
+## Points clés architecture
+
+- La table `palmares` est la source des données Calibre (pas `livres`)
+- Tous les JOINs sont `LEFT JOIN palmares` → un livre sans entrée palmares a calibre=false/null
+- `CalibreBadge` est le seul composable UI à créer — réutilisé sur 3 écrans
+- Le palmarès avait déjà son propre code inline (non refactorisé, pour ne pas toucher du code stable)


### PR DESCRIPTION
## Summary

- Nouveau composable réutilisable `CalibreBadge` : affiche ✓ vert si lu, ◯ gris si dans la bibliothèque non lu, et la note personnelle X/10
- Badge affiché sur la **fiche livre**, la **page auteur** et la **page émission**
- Sur la **fiche livre** : si lu et date de lecture connue dans Calibre, affiche « Lu le DD mois YYYY » en vert
- Les données Calibre proviennent d'un LEFT JOIN sur la table `palmares` (source unique)

## Test plan

- [x] Tests unitaires `CalibreBadgeRepositoryTest` : propagation calibreLu/calibreRating/dateLecture dans LivresRepository et AuteursRepository
- [x] Tests existants mis à jour (`LivresRepositoryTest`, `UrlCoverPropagationTest`)
- [x] Lint et CI verts
- [x] Testé manuellement sur device : badge ✓ + note + date sur la fiche Jean-Philippe Toussaint

Fixes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)