### PR TITLE
feat: livres Calibre lus hors Masque dans Mon Palmarès et page auteur (#85)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
     ksp(libs.androidx.room.compiler)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+    implementation(libs.androidx.datastore.preferences)
 
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.coroutines.test)

--- a/app/src/main/java/com/lmelp/mobile/LmelpApp.kt
+++ b/app/src/main/java/com/lmelp/mobile/LmelpApp.kt
@@ -17,6 +17,7 @@ import com.lmelp.mobile.data.repository.OnKindleRepository
 import com.lmelp.mobile.data.repository.PalmaresRepository
 import com.lmelp.mobile.data.repository.RecommendationsRepository
 import com.lmelp.mobile.data.repository.SearchRepository
+import com.lmelp.mobile.data.repository.UserPreferencesRepository
 import okio.Path.Companion.toOkioPath
 
 class LmelpApp : Application() {
@@ -60,12 +61,13 @@ class LmelpApp : Application() {
     }
     val livresRepository by lazy { LivresRepository(database.livresDao()) }
     val critiquesRepository by lazy { CritiquesRepository(database.critiquesDao()) }
-    val palmaresRepository by lazy { PalmaresRepository(database.palmaresDao()) }
+    val palmaresRepository by lazy { PalmaresRepository(database.palmaresDao(), database.calibreHorsMasqueDao()) }
     val recommendationsRepository by lazy { RecommendationsRepository(database.recommendationsDao()) }
     val searchRepository by lazy { SearchRepository(database.searchDao()) }
     val metadataRepository by lazy { MetadataRepository(database.metadataDao()) }
-    val auteursRepository by lazy { AuteursRepository(database.auteursDao()) }
+    val auteursRepository by lazy { AuteursRepository(database.auteursDao(), database.calibreHorsMasqueDao()) }
     val onKindleRepository by lazy { OnKindleRepository(database.onKindleDao()) }
+    val userPreferencesRepository by lazy { UserPreferencesRepository(this) }
     val homeRepository by lazy {
         HomeRepository(
             database.metadataDao(),

--- a/app/src/main/java/com/lmelp/mobile/Navigation.kt
+++ b/app/src/main/java/com/lmelp/mobile/Navigation.kt
@@ -125,6 +125,7 @@ fun LmelpNavHost(
         ) {
             PalmaresScreen(
                 repository = app.palmaresRepository,
+                userPrefsRepository = app.userPreferencesRepository,
                 onLivreClick = { navController.navigate(Routes.livreDetail(it)) }
             )
         }

--- a/app/src/main/java/com/lmelp/mobile/data/db/CalibreHorsMasqueDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/CalibreHorsMasqueDao.kt
@@ -1,0 +1,30 @@
+package com.lmelp.mobile.data.db
+
+import androidx.room.Dao
+import androidx.room.Query
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
+
+@Dao
+interface CalibreHorsMasqueDao {
+
+    @Query("""
+        SELECT * FROM calibre_hors_masque
+        ORDER BY
+            CASE WHEN calibre_rating IS NULL THEN 1 ELSE 0 END,
+            calibre_rating DESC,
+            titre ASC
+    """)
+    suspend fun getAll(): List<CalibreHorsMasqueEntity>
+
+    @Query("""
+        SELECT * FROM calibre_hors_masque
+        ORDER BY
+            CASE WHEN date_lecture IS NULL THEN 1 ELSE 0 END,
+            date_lecture DESC,
+            titre ASC
+    """)
+    suspend fun getAllParDate(): List<CalibreHorsMasqueEntity>
+
+    @Query("SELECT * FROM calibre_hors_masque WHERE auteur_nom = :auteurNom ORDER BY calibre_rating DESC, titre ASC")
+    suspend fun getByAuteurNom(auteurNom: String): List<CalibreHorsMasqueEntity>
+}

--- a/app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt
@@ -8,6 +8,7 @@ import androidx.room.RoomDatabase
 import com.lmelp.mobile.data.model.AvisCritiquesEntity
 import com.lmelp.mobile.data.model.AvisEntity
 import com.lmelp.mobile.data.model.AuteurEntity
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
 import com.lmelp.mobile.data.model.CritiqueEntity
 import com.lmelp.mobile.data.model.DbMetadataEntity
 import com.lmelp.mobile.data.model.EmissionEntity
@@ -32,8 +33,9 @@ import com.lmelp.mobile.data.model.RecommendationEntity
         AvisCritiquesEntity::class,
         DbMetadataEntity::class,
         OnKindleEntity::class,
+        CalibreHorsMasqueEntity::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = false
 )
 abstract class LmelpDatabase : RoomDatabase() {
@@ -49,6 +51,7 @@ abstract class LmelpDatabase : RoomDatabase() {
     abstract fun avisCritiquesDao(): AvisCritiquesDao
     abstract fun auteursDao(): AuteursDao
     abstract fun onKindleDao(): OnKindleDao
+    abstract fun calibreHorsMasqueDao(): CalibreHorsMasqueDao
 
     companion object {
         @Volatile

--- a/app/src/main/java/com/lmelp/mobile/data/model/Entities.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/Entities.kt
@@ -174,6 +174,15 @@ data class OnKindleEntity(
     @ColumnInfo(name = "nb_avis", defaultValue = "0") val nbAvis: Int = 0
 )
 
+@Entity(tableName = "calibre_hors_masque")
+data class CalibreHorsMasqueEntity(
+    @PrimaryKey val id: String,
+    val titre: String,
+    @ColumnInfo(name = "auteur_nom") val auteurNom: String?,
+    @ColumnInfo(name = "calibre_rating") val calibreRating: Double?,
+    @ColumnInfo(name = "date_lecture") val dateLecture: String?
+)
+
 @Entity(tableName = "db_metadata")
 data class DbMetadataEntity(
     @PrimaryKey val key: String,

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -116,7 +116,8 @@ data class LivreParAuteurUi(
 data class AuteurDetailUi(
     val id: String,
     val nom: String,
-    val livres: List<LivreParAuteurUi>
+    val livres: List<LivreParAuteurUi>,
+    val livresHorsMasque: List<CalibreHorsMasqueUi> = emptyList()
 )
 
 data class DerniereEmissionUi(
@@ -145,6 +146,28 @@ data class OnKindleUi(
     val discusseAuMasque: Boolean = noteMoyenne != null,
     val urlCover: String? = null,
     val scoreHybride: Double? = null
+)
+
+data class CalibreHorsMasqueUi(
+    val id: String,
+    val titre: String,
+    val auteurNom: String?,
+    val calibreRating: Double?,
+    val dateLecture: String?
+)
+
+/**
+ * Item unifié pour Mon Palmarès : peut être un livre du Masque (livreId != null, cliquable)
+ * ou un livre hors Masque (livreId == null, non cliquable, sans couverture).
+ */
+data class MonPalmaresItemUi(
+    val id: String,
+    val titre: String,
+    val auteurNom: String?,
+    val calibreRating: Double?,
+    val dateLecture: String?,
+    val livreId: String? = null,
+    val urlCover: String? = null
 )
 
 data class DbInfoUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt
@@ -1,11 +1,14 @@
 package com.lmelp.mobile.data.repository
 
 import com.lmelp.mobile.data.db.AuteursDao
+import com.lmelp.mobile.data.db.CalibreHorsMasqueDao
 import com.lmelp.mobile.data.model.AuteurDetailUi
+import com.lmelp.mobile.data.model.CalibreHorsMasqueUi
 import com.lmelp.mobile.data.model.LivreParAuteurUi
 
 class AuteursRepository(
-    private val auteursDao: AuteursDao
+    private val auteursDao: AuteursDao,
+    private val horsMasqueDao: CalibreHorsMasqueDao? = null
 ) {
 
     suspend fun getAuteurDetail(auteurId: String): AuteurDetailUi? {
@@ -26,10 +29,22 @@ class AuteursRepository(
                 )
             }
 
+        val livresHorsMasque = horsMasqueDao
+            ?.getByAuteurNom(auteur.nom)
+            .orEmpty()
+            .map { CalibreHorsMasqueUi(
+                id = it.id,
+                titre = it.titre,
+                auteurNom = it.auteurNom,
+                calibreRating = it.calibreRating,
+                dateLecture = it.dateLecture
+            )}
+
         return AuteurDetailUi(
             id = auteur.id,
             nom = auteur.nom,
-            livres = livres
+            livres = livres,
+            livresHorsMasque = livresHorsMasque
         )
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
@@ -1,13 +1,18 @@
 package com.lmelp.mobile.data.repository
 
+import com.lmelp.mobile.data.db.CalibreHorsMasqueDao
 import com.lmelp.mobile.data.db.MonPalmaresRow
 import com.lmelp.mobile.data.db.PalmaresFiltreAvecUrlRow
 import com.lmelp.mobile.data.db.PalmaresDao
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
+import com.lmelp.mobile.data.model.CalibreHorsMasqueUi
+import com.lmelp.mobile.data.model.MonPalmaresItemUi
 import com.lmelp.mobile.data.model.PalmaresEntity
 import com.lmelp.mobile.data.model.PalmaresUi
 
 class PalmaresRepository(
-    private val palmaresDao: PalmaresDao
+    private val palmaresDao: PalmaresDao,
+    private val horsMasqueDao: CalibreHorsMasqueDao? = null
 ) {
 
     suspend fun getAllPalmares(): List<PalmaresUi> {
@@ -26,6 +31,44 @@ class PalmaresRepository(
 
     suspend fun getMonPalmaresParDate(): List<PalmaresUi> =
         palmaresDao.getMonPalmaresParDate().map { it.toUi() }
+
+    /** Livres hors Masque triés par note décroissante, sans note en fin. */
+    suspend fun getMonPalmaresHorsMasque(): List<MonPalmaresItemUi> =
+        horsMasqueDao?.getAll().orEmpty().map { it.toItemUi() }
+
+    /** Livres hors Masque triés par date lecture décroissante, sans date en fin. */
+    suspend fun getMonPalmaresHorsMasqueParDate(): List<MonPalmaresItemUi> =
+        horsMasqueDao?.getAllParDate().orEmpty().map { it.toItemUi() }
+
+    /** Livres hors Masque pour un auteur donné (match sur auteur_nom). */
+    suspend fun getHorsMasqueByAuteurNom(auteurNom: String): List<CalibreHorsMasqueUi> =
+        horsMasqueDao?.getByAuteurNom(auteurNom).orEmpty().map { it.toCalibreUi() }
+
+    /** Fusionne livres Masque + hors Masque en une liste unifiée triée par note. */
+    suspend fun getMonPalmaresUnifieParNote(): List<MonPalmaresItemUi> {
+        val masque = palmaresDao.getMonPalmares().map { it.toItemUi() }
+        val horsMasque = horsMasqueDao?.getAll().orEmpty().map { it.toItemUi() }
+        return (masque + horsMasque).sortedWith(
+            compareBy(
+                { if (it.calibreRating == null) 1 else 0 },
+                { -(it.calibreRating ?: 0.0) },
+                { it.titre }
+            )
+        )
+    }
+
+    /** Fusionne livres Masque + hors Masque en une liste unifiée triée par date. */
+    suspend fun getMonPalmaresUnifieParDate(): List<MonPalmaresItemUi> {
+        val masque = palmaresDao.getMonPalmaresParDate().map { it.toItemUi() }
+        val horsMasque = horsMasqueDao?.getAllParDate().orEmpty().map { it.toItemUi() }
+        return (masque + horsMasque).sortedWith(
+            compareBy(
+                { if (it.dateLecture == null) 1 else 0 },
+                { it.dateLecture?.let { d -> -d.replace("-", "").toLong() } ?: 0L },
+                { it.titre }
+            )
+        )
+    }
 
     private fun PalmaresEntity.toUi() = PalmaresUi(
         rank = rank,
@@ -67,6 +110,34 @@ class PalmaresRepository(
         calibreLu = true,
         calibreRating = calibreRating,
         urlCover = urlCover,
+        dateLecture = dateLecture
+    )
+
+    private fun MonPalmaresRow.toItemUi() = MonPalmaresItemUi(
+        id = livreId,
+        titre = titre,
+        auteurNom = auteurNom,
+        calibreRating = calibreRating,
+        dateLecture = dateLecture,
+        livreId = livreId,
+        urlCover = urlCover
+    )
+
+    private fun CalibreHorsMasqueEntity.toItemUi() = MonPalmaresItemUi(
+        id = id,
+        titre = titre,
+        auteurNom = auteurNom,
+        calibreRating = calibreRating,
+        dateLecture = dateLecture,
+        livreId = null,
+        urlCover = null
+    )
+
+    private fun CalibreHorsMasqueEntity.toCalibreUi() = CalibreHorsMasqueUi(
+        id = id,
+        titre = titre,
+        auteurNom = auteurNom,
+        calibreRating = calibreRating,
         dateLecture = dateLecture
     )
 }

--- a/app/src/main/java/com/lmelp/mobile/data/repository/UserPreferencesRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/UserPreferencesRepository.kt
@@ -1,0 +1,26 @@
+package com.lmelp.mobile.data.repository
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "user_prefs")
+
+class UserPreferencesRepository(private val context: Context) {
+
+    private val SHOW_HORS_MASQUE = booleanPreferencesKey("show_hors_masque")
+
+    val showHorsMasque: Flow<Boolean> = context.dataStore.data
+        .map { prefs -> prefs[SHOW_HORS_MASQUE] ?: true }
+
+    suspend fun setShowHorsMasque(show: Boolean) {
+        context.dataStore.edit { prefs ->
+            prefs[SHOW_HORS_MASQUE] = show
+        }
+    }
+}

--- a/app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -22,9 +23,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lmelp.mobile.data.model.CalibreHorsMasqueUi
 import com.lmelp.mobile.data.model.LivreParAuteurUi
 import com.lmelp.mobile.data.repository.AuteursRepository
 import com.lmelp.mobile.ui.components.CalibreBadge
@@ -65,7 +68,7 @@ fun AuteurDetailScreen(
             uiState.error != null -> ErrorMessage(uiState.error!!, Modifier.padding(padding))
             uiState.auteur != null -> {
                 val auteur = uiState.auteur!!
-                if (auteur.livres.isEmpty()) {
+                if (auteur.livres.isEmpty() && auteur.livresHorsMasque.isEmpty()) {
                     EmptyState("Aucun livre trouvé", Modifier.padding(padding))
                 } else {
                     LazyColumn(modifier = Modifier.padding(padding)) {
@@ -74,6 +77,20 @@ fun AuteurDetailScreen(
                                 livre = livre,
                                 onClick = { onLivreClick(livre.livreId) }
                             )
+                        }
+                        if (auteur.livresHorsMasque.isNotEmpty()) {
+                            item {
+                                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                                Text(
+                                    text = "Lus hors Masque",
+                                    style = MaterialTheme.typography.titleSmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                                )
+                            }
+                            items(auteur.livresHorsMasque, key = { "hors_${it.id}" }) { livre ->
+                                HorsMasqueCard(livre = livre)
+                            }
                         }
                     }
                 }
@@ -121,6 +138,45 @@ fun LivreParAuteurCard(livre: LivreParAuteurUi, onClick: () -> Unit) {
                     calibreLu = livre.calibreLu,
                     calibreRating = livre.calibreRating,
                     modifier = Modifier.padding(start = 8.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun HorsMasqueCard(livre: CalibreHorsMasqueUi) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = livre.titre,
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                livre.dateLecture?.let {
+                    Text(
+                        text = "Lu le ${it.substring(8, 10)}/${it.substring(5, 7)}/${it.substring(0, 4)}",
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
+            }
+            livre.calibreRating?.let {
+                Text(
+                    text = "${it.toInt()}/10",
+                    style = MaterialTheme.typography.titleMedium,
+                    color = Color(0xFF2E7D32)
                 )
             }
         }

--- a/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -30,8 +31,10 @@ import com.lmelp.mobile.ui.theme.LmelpVert
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lmelp.mobile.data.model.MonPalmaresItemUi
 import com.lmelp.mobile.data.model.PalmaresUi
 import com.lmelp.mobile.data.repository.PalmaresRepository
+import com.lmelp.mobile.data.repository.UserPreferencesRepository
 import com.lmelp.mobile.ui.components.BookCoverThumbnail
 import com.lmelp.mobile.ui.components.EmptyState
 import com.lmelp.mobile.ui.components.ErrorMessage
@@ -46,9 +49,10 @@ import com.lmelp.mobile.viewmodel.PalmaresViewModel
 @Composable
 fun PalmaresScreen(
     repository: PalmaresRepository,
+    userPrefsRepository: UserPreferencesRepository? = null,
     onLivreClick: (String) -> Unit
 ) {
-    val viewModel: PalmaresViewModel = viewModel(factory = PalmaresViewModel.Factory(repository))
+    val viewModel: PalmaresViewModel = viewModel(factory = PalmaresViewModel.Factory(repository, userPrefsRepository))
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Scaffold(
@@ -68,6 +72,7 @@ fun PalmaresScreen(
             onToggleNonLus = { viewModel.setAfficherNonLus(!uiState.afficherNonLus) },
             onSetPalmaresMode = { viewModel.setPalmaresMode(it) },
             onSetMonPalmaresTriMode = { viewModel.setMonPalmaresTriMode(it) },
+            onToggleHorsMasque = { viewModel.setShowHorsMasque(!uiState.showHorsMasque) },
             modifier = Modifier.padding(padding)
         )
     }
@@ -82,6 +87,7 @@ fun PalmaresContent(
     onToggleNonLus: () -> Unit,
     onSetPalmaresMode: (PalmaresMode) -> Unit,
     onSetMonPalmaresTriMode: (MonPalmaresTriMode) -> Unit,
+    onToggleHorsMasque: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     Column(modifier = modifier) {
@@ -134,23 +140,30 @@ fun PalmaresContent(
                     onClick = { onSetMonPalmaresTriMode(MonPalmaresTriMode.DATE_LECTURE) },
                     label = { Text("Date lecture ↓") }
                 )
+                Spacer(modifier = Modifier.weight(1f))
+                FilterChip(
+                    selected = uiState.showHorsMasque,
+                    onClick = onToggleHorsMasque,
+                    label = { Text("Hors Masque") }
+                )
             }
         }
 
         when {
             uiState.isLoading -> LoadingIndicator()
             uiState.error != null -> ErrorMessage(uiState.error)
-            uiState.palmares.isEmpty() -> EmptyState(
-                if (uiState.palmaresMode == PalmaresMode.PERSONNEL) "Aucun livre lu"
-                else "Palmarès vide"
-            )
+            uiState.palmaresMode == PalmaresMode.PERSONNEL && uiState.monPalmares.isEmpty() ->
+                EmptyState("Aucun livre lu")
+            uiState.palmaresMode == PalmaresMode.CRITIQUES && uiState.palmares.isEmpty() ->
+                EmptyState("Palmarès vide")
+            uiState.palmaresMode == PalmaresMode.PERSONNEL -> LazyColumn {
+                items(uiState.monPalmares, key = { it.id }) { item ->
+                    MonPalmaresCard(item = item, onLivreClick = onLivreClick)
+                }
+            }
             else -> LazyColumn {
                 items(uiState.palmares, key = { it.livreId }) { item ->
-                    if (uiState.palmaresMode == PalmaresMode.PERSONNEL) {
-                        MonPalmaresCard(item = item, onClick = { onLivreClick(item.livreId) })
-                    } else {
-                        PalmaresCard(item = item, onClick = { onLivreClick(item.livreId) })
-                    }
+                    PalmaresCard(item = item, onClick = { onLivreClick(item.livreId) })
                 }
             }
         }
@@ -210,19 +223,25 @@ fun PalmaresCard(item: PalmaresUi, onClick: () -> Unit) {
 }
 
 @Composable
-fun MonPalmaresCard(item: PalmaresUi, onClick: () -> Unit) {
+fun MonPalmaresCard(item: MonPalmaresItemUi, onLivreClick: (String) -> Unit) {
+    val isClickable = item.livreId != null
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp)
-            .clickable(onClick = onClick)
+            .then(
+                if (isClickable) Modifier.clickable { onLivreClick(item.livreId!!) }
+                else Modifier
+            )
     ) {
         Row(
             modifier = Modifier.padding(12.dp),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            BookCoverThumbnail(urlCover = item.urlCover)
+            if (isClickable) {
+                BookCoverThumbnail(urlCover = item.urlCover)
+            }
             Column(modifier = Modifier.weight(1f)) {
                 Text(text = item.titre, style = MaterialTheme.typography.titleSmall)
                 item.auteurNom?.let { Text(it, style = MaterialTheme.typography.bodySmall) }

--- a/app/src/main/java/com/lmelp/mobile/viewmodel/PalmaresViewModel.kt
+++ b/app/src/main/java/com/lmelp/mobile/viewmodel/PalmaresViewModel.kt
@@ -3,12 +3,15 @@ package com.lmelp.mobile.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.lmelp.mobile.data.model.MonPalmaresItemUi
 import com.lmelp.mobile.data.model.PalmaresUi
 import com.lmelp.mobile.data.repository.PalmaresRepository
+import com.lmelp.mobile.data.repository.UserPreferencesRepository
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -18,20 +21,29 @@ enum class MonPalmaresTriMode { NOTE_PERSO, DATE_LECTURE }
 data class PalmaresUiState(
     val isLoading: Boolean = false,
     val palmares: List<PalmaresUi> = emptyList(),
+    val monPalmares: List<MonPalmaresItemUi> = emptyList(),
     val error: String? = null,
     val afficherLus: Boolean = false,
     val afficherNonLus: Boolean = true,
     val palmaresMode: PalmaresMode = PalmaresMode.CRITIQUES,
-    val monPalmaresTriMode: MonPalmaresTriMode = MonPalmaresTriMode.NOTE_PERSO
+    val monPalmaresTriMode: MonPalmaresTriMode = MonPalmaresTriMode.NOTE_PERSO,
+    val showHorsMasque: Boolean = true
 )
 
-class PalmaresViewModel(private val repository: PalmaresRepository) : ViewModel() {
+class PalmaresViewModel(
+    private val repository: PalmaresRepository,
+    private val userPrefsRepository: UserPreferencesRepository? = null
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PalmaresUiState())
     val uiState: StateFlow<PalmaresUiState> = _uiState.asStateFlow()
 
     init {
-        loadPalmares()
+        viewModelScope.launch {
+            val showHorsMasque = userPrefsRepository?.showHorsMasque?.first() ?: true
+            _uiState.update { it.copy(showHorsMasque = showHorsMasque) }
+            loadPalmares()
+        }
     }
 
     fun setAfficherLus(afficher: Boolean) {
@@ -54,22 +66,37 @@ class PalmaresViewModel(private val repository: PalmaresRepository) : ViewModel(
         loadPalmares()
     }
 
+    fun setShowHorsMasque(show: Boolean) {
+        _uiState.update { it.copy(showHorsMasque = show) }
+        viewModelScope.launch {
+            userPrefsRepository?.setShowHorsMasque(show)
+        }
+        loadPalmares()
+    }
+
     private fun loadPalmares() {
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
             try {
                 val state = _uiState.value
-                val palmares = when (state.palmaresMode) {
-                    PalmaresMode.CRITIQUES -> repository.getPalmaresFiltres(
-                        afficherLus = state.afficherLus,
-                        afficherNonLus = state.afficherNonLus
-                    )
-                    PalmaresMode.PERSONNEL -> when (state.monPalmaresTriMode) {
-                        MonPalmaresTriMode.NOTE_PERSO -> repository.getMonPalmares()
-                        MonPalmaresTriMode.DATE_LECTURE -> repository.getMonPalmaresParDate()
+                when (state.palmaresMode) {
+                    PalmaresMode.CRITIQUES -> {
+                        val palmares = repository.getPalmaresFiltres(
+                            afficherLus = state.afficherLus,
+                            afficherNonLus = state.afficherNonLus
+                        )
+                        _uiState.update { it.copy(isLoading = false, palmares = palmares) }
+                    }
+                    PalmaresMode.PERSONNEL -> {
+                        val allItems = when (state.monPalmaresTriMode) {
+                            MonPalmaresTriMode.NOTE_PERSO -> repository.getMonPalmaresUnifieParNote()
+                            MonPalmaresTriMode.DATE_LECTURE -> repository.getMonPalmaresUnifieParDate()
+                        }
+                        val monPalmares = if (state.showHorsMasque) allItems
+                            else allItems.filter { it.livreId != null }
+                        _uiState.update { it.copy(isLoading = false, monPalmares = monPalmares) }
                     }
                 }
-                _uiState.update { it.copy(isLoading = false, palmares = palmares) }
             } catch (e: Exception) {
                 if (e is CancellationException) throw e
                 _uiState.update { it.copy(isLoading = false, error = e.message) }
@@ -77,10 +104,13 @@ class PalmaresViewModel(private val repository: PalmaresRepository) : ViewModel(
         }
     }
 
-    class Factory(private val repository: PalmaresRepository) : ViewModelProvider.Factory {
+    class Factory(
+        private val repository: PalmaresRepository,
+        private val userPrefsRepository: UserPreferencesRepository? = null
+    ) : ViewModelProvider.Factory {
         override fun <T : ViewModel> create(modelClass: Class<T>): T {
             @Suppress("UNCHECKED_CAST")
-            return PalmaresViewModel(repository) as T
+            return PalmaresViewModel(repository, userPrefsRepository) as T
         }
     }
 }

--- a/app/src/test/java/com/lmelp/mobile/CalibreHorsMasqueRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/CalibreHorsMasqueRepositoryTest.kt
@@ -1,0 +1,123 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.CalibreHorsMasqueDao
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
+import com.lmelp.mobile.data.model.MonPalmaresItemUi
+import com.lmelp.mobile.data.repository.PalmaresRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests TDD pour les livres hors Masque (issue #85).
+ * Ces livres sont lus dans Calibre mais non discutés au Masque et la Plume.
+ */
+class CalibreHorsMasqueRepositoryTest {
+
+    private fun makeHorsMasque(
+        id: String,
+        titre: String = "Titre $id",
+        auteurNom: String? = "Auteur",
+        calibreRating: Double? = null,
+        dateLecture: String? = null
+    ) = CalibreHorsMasqueEntity(
+        id = id,
+        titre = titre,
+        auteurNom = auteurNom,
+        calibreRating = calibreRating,
+        dateLecture = dateLecture
+    )
+
+    // --- getMonPalmaresHorsMasque (tri par note) ---
+
+    @Test
+    fun `getMonPalmaresHorsMasque returns items mapped to MonPalmaresItemUi with livreId null`() = runTest {
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        whenever(horsMasqueDao.getAll()).thenReturn(
+            listOf(makeHorsMasque("h1", calibreRating = 8.0))
+        )
+        val repo = PalmaresRepository(mock(), horsMasqueDao)
+        val result = repo.getMonPalmaresHorsMasque()
+
+        assertEquals(1, result.size)
+        assertNull("livreId doit être null pour hors Masque", result[0].livreId)
+        assertEquals("h1", result[0].id)
+        assertEquals(8.0, result[0].calibreRating!!, 0.001)
+    }
+
+    @Test
+    fun `getMonPalmaresHorsMasque items without note have livreId null and no rating`() = runTest {
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        whenever(horsMasqueDao.getAll()).thenReturn(
+            listOf(makeHorsMasque("h1", calibreRating = null))
+        )
+        val repo = PalmaresRepository(mock(), horsMasqueDao)
+        val result = repo.getMonPalmaresHorsMasque()
+
+        assertEquals(1, result.size)
+        assertNull(result[0].livreId)
+        assertNull(result[0].calibreRating)
+    }
+
+    // --- getMonPalmaresHorsMasqueParDate (tri par date) ---
+
+    @Test
+    fun `getMonPalmaresHorsMasqueParDate returns items sorted by date desc`() = runTest {
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        whenever(horsMasqueDao.getAllParDate()).thenReturn(
+            listOf(
+                makeHorsMasque("h2", dateLecture = "2024-06-01"),
+                makeHorsMasque("h1", dateLecture = "2024-01-01")
+            )
+        )
+        val repo = PalmaresRepository(mock(), horsMasqueDao)
+        val result = repo.getMonPalmaresHorsMasqueParDate()
+
+        assertEquals(2, result.size)
+        assertEquals("h2", result[0].id)
+        assertEquals("h1", result[1].id)
+    }
+
+    @Test
+    fun `getMonPalmaresHorsMasqueParDate items without date have dateLecture null`() = runTest {
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        whenever(horsMasqueDao.getAllParDate()).thenReturn(
+            listOf(makeHorsMasque("h1", dateLecture = null))
+        )
+        val repo = PalmaresRepository(mock(), horsMasqueDao)
+        val result = repo.getMonPalmaresHorsMasqueParDate()
+
+        assertNull(result[0].dateLecture)
+    }
+
+    // --- getHorsMasqueByAuteurNom ---
+
+    @Test
+    fun `getHorsMasqueByAuteurNom returns only items matching auteur`() = runTest {
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        whenever(horsMasqueDao.getByAuteurNom(any())).thenReturn(
+            listOf(makeHorsMasque("h1", auteurNom = "Modiano"))
+        )
+        val repo = PalmaresRepository(mock(), horsMasqueDao)
+        val result = repo.getHorsMasqueByAuteurNom("Modiano")
+
+        assertEquals(1, result.size)
+        assertEquals("Modiano", result[0].auteurNom)
+    }
+
+    @Test
+    fun `getHorsMasqueByAuteurNom returns empty list when no match`() = runTest {
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        whenever(horsMasqueDao.getByAuteurNom(any())).thenReturn(emptyList())
+        val repo = PalmaresRepository(mock(), horsMasqueDao)
+        val result = repo.getHorsMasqueByAuteurNom("Inconnu")
+
+        assertTrue(result.isEmpty())
+    }
+}

--- a/docs/claude/memory/260409-2218-issue85-livres-hors-masque.md
+++ b/docs/claude/memory/260409-2218-issue85-livres-hors-masque.md
@@ -1,0 +1,123 @@
+# Issue #85 — Livres lus hors Masque dans Mon Palmarès et page auteur
+
+## Problème résolu
+
+"Mon Palmarès" n'affichait que les livres discutés au Masque et la Plume (table `palmares`).
+L'issue demandait d'y ajouter les livres Calibre lus mais **non discutés au Masque**, avec :
+- Affichage intégré dans Mon Palmarès (même flux de tri, sans section séparée)
+- Chip "Hors Masque" pour filtrer, aligné à droite, préférence persistante
+- Section "Lus hors Masque" dans la page auteur si livres correspondants
+
+## Nouvelle table SQLite
+
+```sql
+CREATE TABLE calibre_hors_masque (
+    id             TEXT PRIMARY KEY,   -- titre normalisé (slug)
+    titre          TEXT NOT NULL,
+    auteur_nom     TEXT,
+    calibre_rating REAL,
+    date_lecture   TEXT
+)
+```
+
+Logique script Python : livres Calibre avec `calibre_lu=1` dont le titre normalisé n'est PAS dans `palmares`.
+**193 livres** insérés après le premier export.
+
+## Fichiers modifiés
+
+### Script Python
+
+**`scripts/export_mongo_to_sqlite.py`**
+- Nouvelle table `calibre_hors_masque` dans `SCHEMA_SQL`
+- Nouvelle fonction `build_calibre_hors_masque_table()` : charge tous les livres Calibre lus, exclut ceux déjà dans `palmares` (titre normalisé), dédoublonne par titre normalisé
+- Appel dans le flux principal après `import_calibre_data()`
+- `calibre_hors_masque` ajouté dans `verify_database()`
+- `PRAGMA user_version = 6` (était 5)
+
+### Couche données Android
+
+**`app/src/main/java/com/lmelp/mobile/data/model/Entities.kt`**
+- Nouvelle `CalibreHorsMasqueEntity` (`@Entity(tableName = "calibre_hors_masque")`)
+
+**`app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt`**
+- `CalibreHorsMasqueEntity::class` ajouté dans `@Database(entities = [...])`
+- `version = 6` (était 5)
+- Nouvelle méthode abstraite `calibreHorsMasqueDao()`
+
+**`app/src/main/java/com/lmelp/mobile/data/db/CalibreHorsMasqueDao.kt`** (nouveau)
+- `getAll()` : tri note décroissante, sans note en fin
+- `getAllParDate()` : tri date décroissante, sans date en fin
+- `getByAuteurNom(auteurNom)` : filtre par auteur
+
+**`app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt`**
+- Nouveau `CalibreHorsMasqueUi` (id, titre, auteurNom, calibreRating, dateLecture)
+- Nouveau `MonPalmaresItemUi` : wrapper unifié Masque + hors Masque — `livreId == null` signifie "hors Masque, non cliquable"
+- `AuteurDetailUi` enrichi : `livresHorsMasque: List<CalibreHorsMasqueUi> = emptyList()`
+
+**`app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt`**
+- Constructeur enrichi : `horsMasqueDao: CalibreHorsMasqueDao? = null`
+- `getMonPalmaresHorsMasque()` / `getMonPalmaresHorsMasqueParDate()` : livres hors Masque seuls
+- `getHorsMasqueByAuteurNom()` → `List<CalibreHorsMasqueUi>`
+- `getMonPalmaresUnifieParNote()` / `getMonPalmaresUnifieParDate()` : fusion + tri Kotlin côté repo
+
+**`app/src/main/java/com/lmelp/mobile/data/repository/AuteursRepository.kt`**
+- Constructeur enrichi : `horsMasqueDao: CalibreHorsMasqueDao? = null`
+- `getAuteurDetail()` appelle `horsMasqueDao.getByAuteurNom(auteur.nom)` et alimente `livresHorsMasque`
+
+**`app/src/main/java/com/lmelp/mobile/data/repository/UserPreferencesRepository.kt`** (nouveau)
+- DataStore Preferences (`user_prefs`)
+- Clé `show_hors_masque: Boolean` (défaut `true`)
+- `showHorsMasque: Flow<Boolean>` + `setShowHorsMasque()`
+
+### Couche ViewModel
+
+**`app/src/main/java/com/lmelp/mobile/viewmodel/PalmaresViewModel.kt`**
+- `PalmaresUiState` enrichi : `monPalmares: List<MonPalmaresItemUi>`, `showHorsMasque: Boolean = true`
+- Mode PERSONNEL utilise désormais `monPalmares` (pas `palmares`)
+- `init` lit la préférence DataStore avant le premier chargement
+- `setShowHorsMasque()` : persiste dans DataStore + recharge
+- Filtrage côté ViewModel : si `!showHorsMasque`, filtre `monPalmares` pour ne garder que `livreId != null`
+
+### Couche UI
+
+**`app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt`**
+- `PalmaresScreen` accepte `userPrefsRepository: UserPreferencesRepository? = null`
+- `PalmaresContent` : nouveau param `onToggleHorsMasque`
+- Chip "Hors Masque" dans la rangée des filtres PERSONNEL, poussé à droite avec `Spacer(Modifier.weight(1f))`
+- `MonPalmaresCard` refactorisé pour `MonPalmaresItemUi` : si `livreId == null` → pas de `clickable`, pas de `BookCoverThumbnail`
+
+**`app/src/main/java/com/lmelp/mobile/ui/auteurs/AuteurDetailScreen.kt`**
+- Si `auteur.livresHorsMasque.isNotEmpty()` : `HorizontalDivider` + label "Lus hors Masque"
+- Nouveau composable `HorsMasqueCard` : titre + date + note, non cliquable
+
+### Infrastructure
+
+**`app/src/main/java/com/lmelp/mobile/LmelpApp.kt`**
+- `palmaresRepository` : passe `database.calibreHorsMasqueDao()`
+- `auteursRepository` : passe `database.calibreHorsMasqueDao()`
+- `userPreferencesRepository` (nouveau lazy)
+
+**`app/src/main/java/com/lmelp/mobile/Navigation.kt`**
+- Passe `userPrefsRepository = app.userPreferencesRepository` à `PalmaresScreen`
+
+**`gradle/libs.versions.toml`** + **`app/build.gradle.kts`**
+- Ajout `androidx.datastore.preferences:1.1.1`
+
+### Tests
+
+**`app/src/test/java/com/lmelp/mobile/CalibreHorsMasqueRepositoryTest.kt`** (nouveau)
+- `getMonPalmaresHorsMasque()` → `livreId == null`, champs mappés correctement
+- `getMonPalmaresHorsMasqueParDate()` → ordre préservé
+- `getHorsMasqueByAuteurNom()` → filtre correct + liste vide si pas de match
+
+## Points clés architecture
+
+- **Tri Kotlin côté repo** : la fusion Masque + hors Masque se fait dans `PalmaresRepository` (pas côté DAO ni UI) via `sortedWith(compareBy(...))` — gère proprement `null` pour note et date
+- **`MonPalmaresItemUi.livreId == null`** : convention pour "hors Masque, non cliquable" — un seul composable card adaptatif au lieu de deux
+- **DataStore** (pas Room) pour la préférence `show_hors_masque` : persistance légère, asynchrone, lue dans `init` via `first()`
+- **Chip "Hors Masque" aligné à droite** via `Spacer(Modifier.weight(1f))` pour signifier visuellement qu'il s'applique aux deux modes de tri
+- **`horsMasqueDao` optionnel** (`= null`) dans les repositories : les tests existants ne cassent pas
+
+## Version Room
+
+Room version 6 (était 5). Après regénération `lmelp.db` : `adb uninstall com.lmelp.mobile && ./gradlew installDebug` obligatoire.

--- a/docs/dev/build_deploy_apk.md
+++ b/docs/dev/build_deploy_apk.md
@@ -29,6 +29,7 @@ Le container `lmelp-export` fait tout : export MongoDB → push ADB → restart 
 **Pré-requis :**
 
 - Téléphone branché en USB, mode **Transfert de fichiers**
+- Mode développeur activé (Paramètres → À propos du téléphone, et cliquer 7 fois de suite sur Numéro de version)
 - Débogage USB activé (Paramètres → Options développeur)
 - Stack docker-lmelp démarrée (`docker compose up -d`)
 

--- a/docs/dev/data-schema.md
+++ b/docs/dev/data-schema.md
@@ -237,6 +237,30 @@ CREATE TABLE onkindle (
 
 **Tri dans l'app :** le tri alphabétique est effectué en Kotlin via `java.text.Collator(Locale.FRENCH, PRIMARY)` (SQLite ne gère pas les accents correctement pour le français).
 
+### `calibre_hors_masque`
+
+**Table précalculée** à l'export. Livres lus dans Calibre mais **non discutés au Masque et la Plume**.
+
+```sql
+CREATE TABLE calibre_hors_masque (
+    id             TEXT PRIMARY KEY,   -- Titre normalisé (slug, identifiant stable)
+    titre          TEXT NOT NULL,
+    auteur_nom     TEXT,               -- Depuis Calibre (peut différer de livres.auteur_nom)
+    calibre_rating REAL,              -- Note personnelle Calibre (1-10, nullable)
+    date_lecture   TEXT               -- Date de lecture ISO YYYY-MM-DD (nullable)
+);
+```
+
+**Logique de construction (`build_calibre_hors_masque_table`) :**
+1. Charge tous les livres Calibre de la virtual library (`calibre_lu = 1`)
+2. Exclut ceux dont le titre normalisé est déjà dans `palmares`
+3. Dédoublonne par titre normalisé (un livre peut avoir plusieurs auteurs dans Calibre)
+4. Récupère `calibre_rating` et `date_lecture` (même logique que `import_calibre_data`)
+
+**Affichage dans l'app :**
+- **Mon Palmarès** (mode PERSONNEL) : mélangés avec les livres du Masque dans le même flux de tri (note ou date), non cliquables, sans couverture. Chip "Hors Masque" (persistant via DataStore) permet de les masquer.
+- **Page auteur** : section "Lus hors Masque" si `auteur_nom` correspond.
+
 ### `db_metadata`
 
 Métadonnées de la base (version, date d'export).

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ espressoCore = "3.6.1"
 coroutinesTest = "1.8.1"
 mockitoKotlin = "5.4.0"
 coil = "3.1.0"
+datastore = "1.1.1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,6 +43,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 mockito-kotlin = { group = "org.mockito.kotlin", name = "mockito-kotlin", version.ref = "mockitoKotlin" }
 coil-compose = { group = "io.coil-kt.coil3", name = "coil-compose", version.ref = "coil" }
 coil-network-okhttp = { group = "io.coil-kt.coil3", name = "coil-network-okhttp", version.ref = "coil" }
+androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/scripts/export_mongo_to_sqlite.py
+++ b/scripts/export_mongo_to_sqlite.py
@@ -204,6 +204,14 @@ CREATE TABLE IF NOT EXISTS onkindle (
     note_moyenne   REAL,
     nb_avis        INTEGER NOT NULL DEFAULT 0
 );
+
+CREATE TABLE IF NOT EXISTS calibre_hors_masque (
+    id             TEXT NOT NULL PRIMARY KEY,
+    titre          TEXT NOT NULL,
+    auteur_nom     TEXT,
+    calibre_rating REAL,
+    date_lecture   TEXT
+);
 """
 
 
@@ -618,6 +626,141 @@ def import_calibre_data(
 
     except Exception as e:
         logger.error(f"Erreur import Calibre : {e}")
+
+
+def build_calibre_hors_masque_table(
+    cur: sqlite3.Cursor,
+    calibre_db_path: str,
+    virtual_library_tag: str | None = None,
+) -> None:
+    """Construit la table calibre_hors_masque.
+
+    Contient les livres Calibre lus (calibre_lu=1) dont le titre normalisé
+    n'est PAS présent dans palmares. Ce sont des livres lus par l'utilisateur
+    mais non discutés au Masque et la Plume.
+    """
+    logger.info("Building calibre_hors_masque table...")
+
+    try:
+        cal_con = sqlite3.connect(calibre_db_path)
+        cal_con.row_factory = sqlite3.Row
+        cal_cur = cal_con.cursor()
+
+        # Trouve les colonnes personnalisées (read, text/Commentaire)
+        read_col_id: int | None = None
+        row = cal_cur.execute(
+            "SELECT id FROM custom_columns WHERE label = 'read'"
+        ).fetchone()
+        if row:
+            read_col_id = row["id"]
+
+        comment_col_id: int | None = None
+        row = cal_cur.execute(
+            "SELECT id FROM custom_columns WHERE label = 'text'"
+        ).fetchone()
+        if row:
+            comment_col_id = row["id"]
+
+        # Charge les livres Calibre (avec filtre bibliothèque virtuelle si fourni)
+        if virtual_library_tag:
+            cal_cur.execute(
+                """
+                SELECT b.id, b.title, a.name as author_name
+                FROM books b
+                JOIN books_tags_link btl ON b.id = btl.book
+                JOIN tags t ON btl.tag = t.id
+                LEFT JOIN books_authors_link bal ON b.id = bal.book
+                LEFT JOIN authors a ON bal.author = a.id
+                WHERE t.name = ?
+            """,
+                (virtual_library_tag,),
+            )
+        else:
+            cal_cur.execute(
+                """
+                SELECT b.id, b.title, a.name as author_name
+                FROM books b
+                LEFT JOIN books_authors_link bal ON b.id = bal.book
+                LEFT JOIN authors a ON bal.author = a.id
+            """
+            )
+
+        calibre_books = cal_cur.fetchall()
+
+        # Index des titres palmares déjà présents (normalisés)
+        palmares_norms = {
+            _normalize_title(row[0])
+            for row in cur.execute("SELECT titre FROM palmares").fetchall()
+        }
+
+        # Vide la table avant reconstruction
+        cur.execute("DELETE FROM calibre_hors_masque")
+
+        inserted = 0
+        seen_norms: set[str] = set()  # dédoublonnage par titre normalisé
+
+        for book in calibre_books:
+            cal_id = book["id"]
+            titre = book["title"]
+            auteur_nom = book["author_name"]
+            norm = _normalize_title(titre)
+
+            # Ignorer les livres déjà dans palmares
+            if norm in palmares_norms:
+                continue
+
+            # Dédoublonnage (un livre peut avoir plusieurs auteurs dans Calibre)
+            if norm in seen_norms:
+                continue
+
+            # Vérifier si lu
+            calibre_lu = 0
+            if read_col_id is not None:
+                lu_row = cal_cur.execute(
+                    f"SELECT value FROM custom_column_{read_col_id} WHERE book = ?",
+                    (cal_id,),
+                ).fetchone()
+                if lu_row and lu_row["value"]:
+                    calibre_lu = 1
+
+            if not calibre_lu:
+                continue
+
+            # Rating
+            calibre_rating: float | None = None
+            rating_row = cal_cur.execute(
+                """SELECT r.rating FROM ratings r
+                   JOIN books_ratings_link brl ON r.id = brl.rating
+                   WHERE brl.book = ?""",
+                (cal_id,),
+            ).fetchone()
+            if rating_row and rating_row["rating"] is not None:
+                calibre_rating = float(rating_row["rating"])
+
+            # Date de lecture
+            date_lecture: str | None = None
+            if comment_col_id is not None:
+                comment_row = cal_cur.execute(
+                    f"SELECT value FROM custom_column_{comment_col_id} WHERE book = ?",
+                    (cal_id,),
+                ).fetchone()
+                if comment_row:
+                    date_lecture = extract_date_lecture(comment_row["value"])
+
+            cur.execute(
+                """INSERT OR REPLACE INTO calibre_hors_masque
+                   (id, titre, auteur_nom, calibre_rating, date_lecture)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (norm, titre, auteur_nom, calibre_rating, date_lecture),
+            )
+            seen_norms.add(norm)
+            inserted += 1
+
+        cal_con.close()
+        logger.info(f"  → {inserted} livres hors Masque insérés")
+
+    except Exception as e:
+        logger.error(f"Erreur build_calibre_hors_masque_table : {e}")
 
 
 def build_onkindle_table(
@@ -1083,7 +1226,7 @@ def write_metadata(cur: sqlite3.Cursor) -> None:
 
     # user_version = version du schéma Room — doit correspondre à @Database(version=N) dans LmelpDatabase.kt
     # v3 : ajout table onkindle (issue #52)
-    cur.execute("PRAGMA user_version = 5")
+    cur.execute("PRAGMA user_version = 6")
 
     logger.info(
         f"  Metadata: version={version}, date={now.strftime('%Y-%m-%d')}, "
@@ -1112,6 +1255,7 @@ def verify_database(db_path: Path) -> None:
         "recommendations",
         "avis_critiques",
         "onkindle",
+        "calibre_hors_masque",
     ]
 
     click.echo(f"\n{'=' * 50}")
@@ -1232,6 +1376,7 @@ def main(
     compute_palmares(cur)
     if calibre_db:
         import_calibre_data(cur, calibre_db, calibre_virtual_library)
+        build_calibre_hors_masque_table(cur, calibre_db, calibre_virtual_library)
         build_onkindle_table(cur, calibre_db, calibre_virtual_library)
     compute_recommendations(cur, n_factors=svd_factors, calibre_db_path=calibre_db)
     build_search_index(cur)


### PR DESCRIPTION
## Summary

- Nouvelle table SQLite `calibre_hors_masque` (193 livres) : livres lus dans Calibre non discutés au Masque et la Plume
- **Mon Palmarès** : livres hors Masque mélangés dans le même flux de tri (note ou date), non cliquables, sans couverture
- **Chip "Hors Masque"** aligné à droite (affiché par défaut), préférence persistante via DataStore
- **Page auteur** : section "Lus hors Masque" si l'auteur a des livres correspondants (match sur `auteur_nom`)
- Room version 5 → 6 (nouveau `adb uninstall` requis)

## Test plan

- [x] Tests unitaires (`CalibreHorsMasqueRepositoryTest`) — GREEN
- [x] Lint — OK
- [x] CI — OK
- [x] Test sur device (Pixel 9 Pro) — validé par l'utilisateur
- [x] Préférence "Hors Masque" persistée après redémarrage

🤖 Generated with [Claude Code](https://claude.com/claude-code)