### PR TITLE
feat(critique): ajouter page de détail pour les critiques (#82)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/Navigation.kt
+++ b/app/src/main/java/com/lmelp/mobile/Navigation.kt
@@ -11,6 +11,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
 import com.lmelp.mobile.ui.about.AboutScreen
 import com.lmelp.mobile.ui.auteurs.AuteurDetailScreen
+import com.lmelp.mobile.ui.critiques.CritiqueDetailScreen
 import com.lmelp.mobile.ui.critiques.CritiquesScreen
 import com.lmelp.mobile.ui.emissions.EmissionDetailScreen
 import com.lmelp.mobile.ui.emissions.EmissionsScreen
@@ -30,6 +31,7 @@ object Routes {
     const val AUTEUR_DETAIL = "auteur/{auteurId}"
     const val PALMARES = "palmares"
     const val CRITIQUES = "critiques"
+    const val CRITIQUE_DETAIL = "critique/{critiqueId}"
     const val SEARCH = "search"
     const val RECOMMENDATIONS = "recommendations"
     const val ONKINDLE = "onkindle"
@@ -37,6 +39,7 @@ object Routes {
     fun emissionDetail(emissionId: String) = "emission/$emissionId"
     fun livreDetail(livreId: String) = "livre/$livreId"
     fun auteurDetail(auteurId: String) = "auteur/$auteurId"
+    fun critiqueDetail(critiqueId: String) = "critique/$critiqueId"
 }
 
 @Composable
@@ -101,7 +104,8 @@ fun LmelpNavHost(
                 repository = app.livresRepository,
                 onBack = { navController.popBackStack() },
                 onEmissionClick = { navController.navigate(Routes.emissionDetail(it)) },
-                onAuteurClick = { navController.navigate(Routes.auteurDetail(it)) }
+                onAuteurClick = { navController.navigate(Routes.auteurDetail(it)) },
+                onCritiqueClick = { navController.navigate(Routes.critiqueDetail(it)) }
             )
         }
 
@@ -131,7 +135,23 @@ fun LmelpNavHost(
         }
 
         composable(Routes.CRITIQUES) {
-            CritiquesScreen(repository = app.critiquesRepository)
+            CritiquesScreen(
+                repository = app.critiquesRepository,
+                onCritiqueClick = { navController.navigate(Routes.critiqueDetail(it)) }
+            )
+        }
+
+        composable(
+            route = Routes.CRITIQUE_DETAIL,
+            arguments = listOf(navArgument("critiqueId") { type = NavType.StringType })
+        ) { backStack ->
+            val critiqueId = backStack.arguments?.getString("critiqueId") ?: return@composable
+            CritiqueDetailScreen(
+                critiqueId = critiqueId,
+                repository = app.critiquesRepository,
+                onBack = { navController.popBackStack() },
+                onLivreClick = { navController.navigate(Routes.livreDetail(it)) }
+            )
         }
 
         composable(Routes.ONKINDLE) {
@@ -154,6 +174,7 @@ fun LmelpNavHost(
                         "livre" -> navController.navigate(Routes.livreDetail(id))
                         "emission" -> navController.navigate(Routes.emissionDetail(id))
                         "auteur" -> navController.navigate(Routes.auteurDetail(id))
+                        "critique" -> navController.navigate(Routes.critiqueDetail(id))
                         else -> {}
                     }
                 }

--- a/app/src/main/java/com/lmelp/mobile/data/db/CritiquesDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/CritiquesDao.kt
@@ -1,8 +1,18 @@
 package com.lmelp.mobile.data.db
 
+import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Query
 import com.lmelp.mobile.data.model.CritiqueEntity
+
+data class AvisParCritiqueRow(
+    @ColumnInfo(name = "livreId") val livreId: String,
+    @ColumnInfo(name = "livreTitre") val livreTitre: String?,
+    @ColumnInfo(name = "auteurNom") val auteurNom: String?,
+    val note: Double?,
+    @ColumnInfo(name = "emissionId") val emissionId: String,
+    @ColumnInfo(name = "emissionDate") val emissionDate: String?
+)
 
 @Dao
 interface CritiquesDao {
@@ -12,4 +22,15 @@ interface CritiquesDao {
 
     @Query("SELECT * FROM critiques WHERE id = :id")
     suspend fun getCritiqueById(id: String): CritiqueEntity?
+
+    @Query("""
+        SELECT a.livre_id as livreId, a.livre_titre as livreTitre,
+               a.auteur_nom as auteurNom, a.note, a.emission_id as emissionId,
+               em.date as emissionDate
+        FROM avis a
+        JOIN emissions em ON em.id = a.emission_id
+        WHERE a.critique_id = :critiqueId
+        ORDER BY a.note DESC
+    """)
+    suspend fun getAvisByCritique(critiqueId: String): List<AvisParCritiqueRow>
 }

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -35,6 +35,7 @@ data class LivreUi(
 
 data class AvisUi(
     val id: String,
+    val critiqueId: String?,
     val critiqueNom: String?,
     val note: Double?,
     val commentaire: String?,
@@ -84,6 +85,24 @@ data class CritiqueUi(
     val nom: String,
     val animateur: Boolean,
     val nbAvis: Int
+)
+
+data class AvisParCritiqueUi(
+    val livreId: String,
+    val livreTitre: String?,
+    val auteurNom: String?,
+    val note: Double?,
+    val emissionDate: String?
+)
+
+data class CritiqueDetailUi(
+    val id: String,
+    val nom: String,
+    val animateur: Boolean,
+    val nbAvis: Int,
+    val noteMoyenne: Double?,
+    val distribution: Map<Int, Int>,
+    val coupsDeCoeur: List<AvisParCritiqueUi>
 )
 
 data class RecommendationUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/CritiquesRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/CritiquesRepository.kt
@@ -1,6 +1,8 @@
 package com.lmelp.mobile.data.repository
 
 import com.lmelp.mobile.data.db.CritiquesDao
+import com.lmelp.mobile.data.model.AvisParCritiqueUi
+import com.lmelp.mobile.data.model.CritiqueDetailUi
 import com.lmelp.mobile.data.model.CritiqueUi
 
 class CritiquesRepository(
@@ -16,5 +18,41 @@ class CritiquesRepository(
                 nbAvis = it.nbAvis
             )
         }
+    }
+
+    suspend fun getCritiqueDetail(critiqueId: String): CritiqueDetailUi? {
+        val critique = critiquesDao.getCritiqueById(critiqueId) ?: return null
+        val avisRows = critiquesDao.getAvisByCritique(critiqueId)
+
+        val avisAvecNote = avisRows.filter { it.note != null }
+        val noteMoyenne = if (avisAvecNote.isEmpty()) null
+        else avisAvecNote.sumOf { it.note!! } / avisAvecNote.size
+
+        val distribution = avisAvecNote
+            .groupBy { it.note!!.toInt() }
+            .mapValues { it.value.size }
+
+        val coupsDeCoeur = avisRows
+            .filter { it.note != null && it.note >= 9.0 }
+            .sortedByDescending { it.note }
+            .map {
+                AvisParCritiqueUi(
+                    livreId = it.livreId,
+                    livreTitre = it.livreTitre,
+                    auteurNom = it.auteurNom,
+                    note = it.note,
+                    emissionDate = it.emissionDate
+                )
+            }
+
+        return CritiqueDetailUi(
+            id = critique.id,
+            nom = critique.nom,
+            animateur = critique.animateur == 1,
+            nbAvis = critique.nbAvis,
+            noteMoyenne = noteMoyenne,
+            distribution = distribution,
+            coupsDeCoeur = coupsDeCoeur
+        )
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
@@ -33,6 +33,7 @@ class LivresRepository(
                         .map { row ->
                             AvisUi(
                                 id = row.avis.id,
+                                critiqueId = row.avis.critiqueId,
                                 critiqueNom = row.avis.critiqueNom,
                                 note = row.avis.note,
                                 commentaire = row.avis.commentaire,

--- a/app/src/main/java/com/lmelp/mobile/ui/critiques/CritiqueDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/critiques/CritiqueDetailScreen.kt
@@ -1,0 +1,278 @@
+package com.lmelp.mobile.ui.critiques
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Badge
+import androidx.compose.material3.Card
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.lmelp.mobile.data.model.AvisParCritiqueUi
+import com.lmelp.mobile.data.model.CritiqueDetailUi
+import com.lmelp.mobile.data.repository.CritiquesRepository
+import com.lmelp.mobile.ui.components.EmptyState
+import com.lmelp.mobile.ui.components.ErrorMessage
+import com.lmelp.mobile.ui.components.LoadingIndicator
+import com.lmelp.mobile.ui.components.NoteBadge
+import com.lmelp.mobile.ui.emissions.formatDateLong
+import com.lmelp.mobile.viewmodel.CritiqueDetailViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CritiqueDetailScreen(
+    critiqueId: String,
+    repository: CritiquesRepository,
+    onBack: () -> Unit,
+    onLivreClick: (String) -> Unit = {}
+) {
+    val viewModel: CritiqueDetailViewModel = viewModel(
+        factory = CritiqueDetailViewModel.Factory(repository, critiqueId)
+    )
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(uiState.critique?.nom ?: "Critique") },
+                navigationIcon = {
+                    IconButton(onClick = onBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Retour")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        when {
+            uiState.isLoading -> LoadingIndicator(Modifier.padding(padding))
+            uiState.error != null -> ErrorMessage(uiState.error!!, Modifier.padding(padding))
+            uiState.critique != null -> CritiqueDetailContent(
+                critique = uiState.critique!!,
+                onLivreClick = onLivreClick,
+                modifier = Modifier.padding(padding)
+            )
+            else -> EmptyState("Critique introuvable", Modifier.padding(padding))
+        }
+    }
+}
+
+@Composable
+fun CritiqueDetailContent(
+    critique: CritiqueDetailUi,
+    onLivreClick: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(modifier = modifier) {
+        item {
+            CritiqueHeader(critique = critique)
+        }
+
+        if (critique.distribution.isNotEmpty()) {
+            item {
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                NoteDistribution(distribution = critique.distribution)
+            }
+        }
+
+        if (critique.coupsDeCoeur.isNotEmpty()) {
+            item {
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                Text(
+                    text = "Coups de cœur (${critique.coupsDeCoeur.size})",
+                    style = MaterialTheme.typography.titleSmall,
+                    fontWeight = FontWeight.Bold,
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)
+                )
+            }
+            items(critique.coupsDeCoeur, key = { "cdc_${it.livreId}" }) { avis ->
+                CoupDeCoeurCard(avis = avis, onClick = { onLivreClick(avis.livreId) })
+            }
+        } else {
+            item {
+                HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp))
+                EmptyState("Aucun coup de cœur")
+            }
+        }
+    }
+}
+
+@Composable
+fun CritiqueHeader(critique: CritiqueDetailUi) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(16.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(modifier = Modifier.weight(1f)) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    text = critique.nom,
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.Bold
+                )
+                if (critique.animateur) {
+                    Badge { Text("animateur") }
+                }
+            }
+            Text(
+                text = "${critique.nbAvis} avis",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        }
+        critique.noteMoyenne?.let {
+            NoteBadge(note = it)
+        }
+    }
+}
+
+private fun noteBarColor(note: Int): Color = when {
+    note >= 9 -> Color(0xFF2E7D32)
+    note >= 7 -> Color(0xFF558B2F)
+    note >= 5 -> Color(0xFFAFB42B)
+    else -> Color(0xFFC62828)
+}
+
+@Composable
+fun NoteDistribution(distribution: Map<Int, Int>) {
+    val maxCount = distribution.values.maxOrNull() ?: 1
+    val chartHeight = 120.dp
+
+    Column(modifier = Modifier.padding(horizontal = 16.dp, vertical = 4.dp)) {
+        Text(
+            text = "Distribution des notes",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(bottom = 8.dp)
+        )
+        // Barres verticales alignées en bas
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.Bottom
+        ) {
+            (1..10).forEach { note ->
+                val count = distribution[note] ?: 0
+                val fraction = if (count > 0) count.toFloat() / maxCount.toFloat() else 0f
+                val barColor = noteBarColor(note)
+                Column(
+                    modifier = Modifier.weight(1f),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Bottom
+                ) {
+                    // Compteur au-dessus de la barre
+                    if (count > 0) {
+                        Text(
+                            text = "$count",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            textAlign = TextAlign.Center,
+                            modifier = Modifier.padding(bottom = 2.dp)
+                        )
+                    }
+                    // Barre (hauteur proportionnelle)
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 2.dp)
+                            .height(chartHeight * fraction)
+                            .clip(RoundedCornerShape(topStart = 4.dp, topEnd = 4.dp))
+                            .background(if (count > 0) barColor else Color.Transparent)
+                    )
+                }
+            }
+        }
+        // Axe X : étiquettes des notes
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly
+        ) {
+            (1..10).forEach { note ->
+                Text(
+                    text = "$note",
+                    style = MaterialTheme.typography.labelSmall,
+                    fontWeight = FontWeight.Bold,
+                    textAlign = TextAlign.Center,
+                    modifier = Modifier.weight(1f).padding(top = 4.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CoupDeCoeurCard(avis: AvisParCritiqueUi, onClick: () -> Unit) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick)
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(12.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = avis.livreTitre ?: "Livre inconnu",
+                    style = MaterialTheme.typography.bodyLarge
+                )
+                avis.auteurNom?.let {
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
+                avis.emissionDate?.let {
+                    Text(
+                        text = formatDateLong(it),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                        modifier = Modifier.padding(top = 2.dp)
+                    )
+                }
+            }
+            avis.note?.let {
+                NoteBadge(note = it)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/lmelp/mobile/ui/critiques/CritiquesScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/critiques/CritiquesScreen.kt
@@ -1,5 +1,6 @@
 package com.lmelp.mobile.ui.critiques
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -36,7 +37,10 @@ import com.lmelp.mobile.viewmodel.CritiquesViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CritiquesScreen(repository: CritiquesRepository) {
+fun CritiquesScreen(
+    repository: CritiquesRepository,
+    onCritiqueClick: (String) -> Unit = {}
+) {
     val viewModel: CritiquesViewModel = viewModel(factory = CritiquesViewModel.Factory(repository))
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
@@ -50,19 +54,23 @@ fun CritiquesScreen(repository: CritiquesRepository) {
             )
         }
     ) { padding ->
-        CritiquesContent(uiState = uiState, modifier = Modifier.padding(padding))
+        CritiquesContent(uiState = uiState, onCritiqueClick = onCritiqueClick, modifier = Modifier.padding(padding))
     }
 }
 
 @Composable
-fun CritiquesContent(uiState: CritiquesUiState, modifier: Modifier = Modifier) {
+fun CritiquesContent(
+    uiState: CritiquesUiState,
+    onCritiqueClick: (String) -> Unit = {},
+    modifier: Modifier = Modifier
+) {
     when {
         uiState.isLoading -> LoadingIndicator(modifier)
         uiState.error != null -> ErrorMessage(uiState.error, modifier)
         uiState.critiques.isEmpty() -> EmptyState("Aucun critique", modifier)
         else -> LazyColumn(modifier = modifier) {
             items(uiState.critiques, key = { it.id }) { critique ->
-                CritiqueCard(critique = critique)
+                CritiqueCard(critique = critique, onClick = { onCritiqueClick(critique.id) })
             }
         }
     }
@@ -70,11 +78,12 @@ fun CritiquesContent(uiState: CritiquesUiState, modifier: Modifier = Modifier) {
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun CritiqueCard(critique: CritiqueUi) {
+fun CritiqueCard(critique: CritiqueUi, onClick: () -> Unit = {}) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp, vertical = 4.dp)
+            .clickable(onClick = onClick)
     ) {
         Row(
             modifier = Modifier.padding(12.dp).fillMaxWidth(),

--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
@@ -62,7 +62,8 @@ fun LivreDetailScreen(
     repository: LivresRepository,
     onBack: () -> Unit,
     onEmissionClick: (String) -> Unit = {},
-    onAuteurClick: (String) -> Unit = {}
+    onAuteurClick: (String) -> Unit = {},
+    onCritiqueClick: (String) -> Unit = {}
 ) {
     val viewModel: LivreDetailViewModel = viewModel(
         factory = LivreDetailViewModel.Factory(repository, livreId)
@@ -88,6 +89,7 @@ fun LivreDetailScreen(
                 livre = uiState.livre!!,
                 onEmissionClick = onEmissionClick,
                 onAuteurClick = onAuteurClick,
+                onCritiqueClick = onCritiqueClick,
                 modifier = Modifier.padding(padding)
             )
             else -> EmptyState("Livre introuvable", Modifier.padding(padding))
@@ -100,6 +102,7 @@ fun LivreDetailContent(
     livre: LivreDetailUi,
     onEmissionClick: (String) -> Unit,
     onAuteurClick: (String) -> Unit = {},
+    onCritiqueClick: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var showCoverFullscreen by remember { mutableStateOf(false) }
@@ -204,7 +207,7 @@ fun LivreDetailContent(
                 )
             }
             items(groupe.avis, key = { it.id }) { avis ->
-                AvisCard(avis = avis)
+                AvisCard(avis = avis, onCritiqueClick = onCritiqueClick)
             }
         }
     }
@@ -235,7 +238,7 @@ fun EmissionGroupHeader(groupe: AvisParEmissionUi, onClick: () -> Unit) {
 }
 
 @Composable
-fun AvisCard(avis: AvisUi) {
+fun AvisCard(avis: AvisUi, onCritiqueClick: (String) -> Unit = {}) {
     Card(
         modifier = Modifier
             .fillMaxWidth()
@@ -243,10 +246,17 @@ fun AvisCard(avis: AvisUi) {
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Row {
+                val critiqueId = avis.critiqueId
                 Text(
                     text = avis.critiqueNom ?: "Critique",
                     style = MaterialTheme.typography.titleSmall,
-                    modifier = Modifier.weight(1f)
+                    color = if (critiqueId != null) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurface,
+                    modifier = Modifier
+                        .weight(1f)
+                        .then(
+                            if (critiqueId != null) Modifier.clickable { onCritiqueClick(critiqueId) }
+                            else Modifier
+                        )
                 )
                 avis.note?.let { NoteBadge(note = it) }
             }

--- a/app/src/main/java/com/lmelp/mobile/viewmodel/CritiqueDetailViewModel.kt
+++ b/app/src/main/java/com/lmelp/mobile/viewmodel/CritiqueDetailViewModel.kt
@@ -1,0 +1,55 @@
+package com.lmelp.mobile.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.lmelp.mobile.data.model.CritiqueDetailUi
+import com.lmelp.mobile.data.repository.CritiquesRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class CritiqueDetailUiState(
+    val isLoading: Boolean = false,
+    val critique: CritiqueDetailUi? = null,
+    val error: String? = null
+)
+
+class CritiqueDetailViewModel(
+    private val repository: CritiquesRepository,
+    private val critiqueId: String
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(CritiqueDetailUiState())
+    val uiState: StateFlow<CritiqueDetailUiState> = _uiState.asStateFlow()
+
+    init {
+        loadCritique()
+    }
+
+    private fun loadCritique() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                val critique = repository.getCritiqueDetail(critiqueId)
+                _uiState.update { it.copy(isLoading = false, critique = critique) }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                _uiState.update { it.copy(isLoading = false, error = e.message) }
+            }
+        }
+    }
+
+    class Factory(
+        private val repository: CritiquesRepository,
+        private val critiqueId: String
+    ) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return CritiqueDetailViewModel(repository, critiqueId) as T
+        }
+    }
+}

--- a/app/src/test/java/com/lmelp/mobile/CritiquesRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/CritiquesRepositoryTest.kt
@@ -1,0 +1,169 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.AvisParCritiqueRow
+import com.lmelp.mobile.data.db.CritiquesDao
+import com.lmelp.mobile.data.model.CritiqueEntity
+import com.lmelp.mobile.data.repository.CritiquesRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class CritiquesRepositoryTest {
+
+    private fun makeCritiqueEntity(id: String, nom: String, nbAvis: Int = 0) = CritiqueEntity(
+        id = id,
+        nom = nom,
+        animateur = 0,
+        nbAvis = nbAvis
+    )
+
+    private fun makeAvisRow(
+        livreId: String,
+        livreTitre: String,
+        auteurNom: String?,
+        note: Double?,
+        emissionId: String = "em1",
+        emissionDate: String? = "2024-01-01"
+    ) = AvisParCritiqueRow(
+        livreId = livreId,
+        livreTitre = livreTitre,
+        auteurNom = auteurNom,
+        note = note,
+        emissionId = emissionId,
+        emissionDate = emissionDate
+    )
+
+    @Test
+    fun `getCritiqueDetail retourne null si critique introuvable`() = runTest {
+        val dao = mock<CritiquesDao>()
+        whenever(dao.getCritiqueById(any())).thenReturn(null)
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("inexistant")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `getCritiqueDetail retourne les infos de base du critique`() = runTest {
+        val dao = mock<CritiquesDao>()
+        whenever(dao.getCritiqueById("c1")).thenReturn(makeCritiqueEntity("c1", "Arnaud Viviant", 50))
+        whenever(dao.getAvisByCritique("c1")).thenReturn(emptyList())
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("c1")!!
+
+        assertEquals("c1", result.id)
+        assertEquals("Arnaud Viviant", result.nom)
+        assertEquals(50, result.nbAvis)
+    }
+
+    @Test
+    fun `getCritiqueDetail calcule la note moyenne`() = runTest {
+        val dao = mock<CritiquesDao>()
+        whenever(dao.getCritiqueById("c1")).thenReturn(makeCritiqueEntity("c1", "Alice"))
+        whenever(dao.getAvisByCritique("c1")).thenReturn(
+            listOf(
+                makeAvisRow("l1", "Livre A", null, 8.0),
+                makeAvisRow("l2", "Livre B", null, 6.0),
+                makeAvisRow("l3", "Livre C", null, 10.0),
+            )
+        )
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("c1")!!
+
+        assertEquals(8.0, result.noteMoyenne!!, 0.01)
+    }
+
+    @Test
+    fun `getCritiqueDetail noteMoyenne null si aucun avis`() = runTest {
+        val dao = mock<CritiquesDao>()
+        whenever(dao.getCritiqueById("c1")).thenReturn(makeCritiqueEntity("c1", "Alice"))
+        whenever(dao.getAvisByCritique("c1")).thenReturn(emptyList())
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("c1")!!
+
+        assertNull(result.noteMoyenne)
+    }
+
+    @Test
+    fun `getCritiqueDetail calcule la distribution des notes`() = runTest {
+        val dao = mock<CritiquesDao>()
+        whenever(dao.getCritiqueById("c1")).thenReturn(makeCritiqueEntity("c1", "Alice"))
+        whenever(dao.getAvisByCritique("c1")).thenReturn(
+            listOf(
+                makeAvisRow("l1", "Livre A", null, 8.0),
+                makeAvisRow("l2", "Livre B", null, 8.0),
+                makeAvisRow("l3", "Livre C", null, 9.0),
+                makeAvisRow("l4", "Livre D", null, null),  // note null ignorée
+            )
+        )
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("c1")!!
+
+        assertEquals(2, result.distribution[8])
+        assertEquals(1, result.distribution[9])
+        assertTrue(result.distribution[7] == null || result.distribution[7] == 0)
+    }
+
+    @Test
+    fun `getCritiqueDetail coups de coeur sont notes 9 et 10`() = runTest {
+        val dao = mock<CritiquesDao>()
+        whenever(dao.getCritiqueById("c1")).thenReturn(makeCritiqueEntity("c1", "Alice"))
+        whenever(dao.getAvisByCritique("c1")).thenReturn(
+            listOf(
+                makeAvisRow("l1", "Chef d'oeuvre", "Auteur A", 10.0),
+                makeAvisRow("l2", "Excellent", "Auteur B", 9.0),
+                makeAvisRow("l3", "Bien", "Auteur C", 8.0),
+                makeAvisRow("l4", "Moyen", "Auteur D", 5.0),
+            )
+        )
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("c1")!!
+
+        assertEquals(2, result.coupsDeCoeur.size)
+        assertTrue(result.coupsDeCoeur.all { it.note!! >= 9.0 })
+        assertEquals("l1", result.coupsDeCoeur[0].livreId)
+        assertEquals("l2", result.coupsDeCoeur[1].livreId)
+    }
+
+    @Test
+    fun `getCritiqueDetail coups de coeur tries par note decroissante`() = runTest {
+        val dao = mock<CritiquesDao>()
+        whenever(dao.getCritiqueById("c1")).thenReturn(makeCritiqueEntity("c1", "Alice"))
+        whenever(dao.getAvisByCritique("c1")).thenReturn(
+            listOf(
+                makeAvisRow("l1", "Livre 9", null, 9.0),
+                makeAvisRow("l2", "Livre 10", null, 10.0),
+                makeAvisRow("l3", "Livre 9b", null, 9.0),
+            )
+        )
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("c1")!!
+
+        assertEquals(10.0, result.coupsDeCoeur[0].note!!, 0.01)
+    }
+
+    @Test
+    fun `getCritiqueDetail animateur flag mappé correctement`() = runTest {
+        val dao = mock<CritiquesDao>()
+        val animateur = CritiqueEntity(id = "c1", nom = "Patrick Sherr", animateur = 1, nbAvis = 5)
+        whenever(dao.getCritiqueById("c1")).thenReturn(animateur)
+        whenever(dao.getAvisByCritique("c1")).thenReturn(emptyList())
+
+        val repo = CritiquesRepository(dao)
+        val result = repo.getCritiqueDetail("c1")!!
+
+        assertTrue(result.animateur)
+    }
+}

--- a/docs/claude/memory/260410-1530-issue82-page-critique.md
+++ b/docs/claude/memory/260410-1530-issue82-page-critique.md
@@ -1,0 +1,52 @@
+# Issue #82 — Page de détail d'un critique
+
+## Résumé
+Ajout d'une page de détail pour chaque critique (journaliste/chroniqueur), accessible depuis 3 points d'entrée : liste des critiques, fiche livre (avis), recherche.
+
+## Fichiers modifiés
+
+### Nouveaux fichiers
+- `app/src/main/java/com/lmelp/mobile/ui/critiques/CritiqueDetailScreen.kt` — écran complet avec en-tête, histogramme vertical des notes, liste des coups de cœur
+- `app/src/main/java/com/lmelp/mobile/viewmodel/CritiqueDetailViewModel.kt` — ViewModel + Factory standard
+- `app/src/test/java/com/lmelp/mobile/CritiquesRepositoryTest.kt` — 7 tests unitaires TDD
+
+### Fichiers modifiés
+- `app/src/main/java/com/lmelp/mobile/data/db/CritiquesDao.kt` — ajout `AvisParCritiqueRow` (data class) + query `getAvisByCritique(critiqueId)`
+- `app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt` — ajout `AvisParCritiqueUi`, `CritiqueDetailUi`, champ `critiqueId: String?` dans `AvisUi`
+- `app/src/main/java/com/lmelp/mobile/data/repository/CritiquesRepository.kt` — ajout `getCritiqueDetail()` : calcule note moyenne, distribution (Map<Int,Int>), coups de cœur (notes ≥ 9)
+- `app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt` — propagation de `critiqueId` dans `AvisUi` (depuis `AvisEntity.critiqueId` déjà présent)
+- `app/src/main/java/com/lmelp/mobile/ui/critiques/CritiquesScreen.kt` — cartes cliquables, paramètre `onCritiqueClick: (String) -> Unit`
+- `app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt` — `AvisCard` : nom du critique affiché en couleur primaire + cliquable si `critiqueId != null`; paramètre `onCritiqueClick` propagé jusqu'à `LivreDetailContent`
+- `app/src/main/java/com/lmelp/mobile/Navigation.kt` — route `Routes.CRITIQUE_DETAIL = "critique/{critiqueId}"`, helper `critiqueDetail()`, composable, câblage depuis LivreDetail et Search (`"critique"` → `critiqueDetail`)
+
+## Points saillants
+
+### Histogramme vertical des notes
+- Barres **verticales** (axe X = notes 1→10 croissant, axe Y = count), alignées en bas
+- Hauteur de chaque barre = `chartHeight * (count / maxCount)` — hauteur fixe 120.dp
+- Couleurs : rouge (≤4), jaune-vert (5-6), vert clair (7-8), vert foncé (9-10)
+- Notes sans avis : barre invisible (Color.Transparent), étiquette X quand même affichée
+- Count affiché au-dessus de chaque barre si > 0
+
+### Coups de cœur
+- Seuil : `note >= 9.0`
+- Triés par note décroissante (le query SQL trie déjà par note DESC)
+- Cartes cliquables → navigation vers `LivreDetailScreen`
+
+### Navigation
+- 3 points d'entrée câblés : liste critiques, fiche livre (AvisCard), recherche (type `"critique"`)
+- Pattern identique aux autres détails (auteur, livre) : route paramétrique + composable dans `LmelpNavHost`
+
+### Modèle de données
+- `AvisParCritiqueRow` : data class Room dans `CritiquesDao.kt` (pas dans Entities), colonnes aliasées avec `@ColumnInfo(name=...)`
+- `critiqueId` ajouté à `AvisUi` sans breaking change (nullable, valeur toujours présente en pratique car FK non null dans AvisEntity)
+
+## Tests
+7 tests dans `CritiquesRepositoryTest` couvrant :
+- retour null si critique inexistant
+- infos de base (id, nom, nbAvis)
+- calcul note moyenne
+- note moyenne null si aucun avis
+- distribution des notes (groupBy + count)
+- coups de cœur filtrés (notes ≥ 9) et triés
+- flag animateur mappé correctement


### PR DESCRIPTION
## Summary

- Nouvelle page `CritiqueDetailScreen` : en-tête (nom, nb avis, note moyenne), histogramme vertical des notes (1→10), liste des coups de cœur (≥9) cliquables vers la fiche livre
- Navigation depuis 3 points d'entrée : liste des critiques, fiche livre (nom critique cliquable en bleu sur AvisCard), recherche (type `critique`)
- `CritiqueDetailViewModel` + `CritiquesRepository.getCritiqueDetail()` (note moyenne, distribution, coups de cœur)
- 7 tests unitaires TDD dans `CritiquesRepositoryTest`

## Test plan

- [ ] Liste Critiques → cliquer une carte → page de détail s'ouvre
- [ ] Page critique : en-tête avec nom, nb avis, note moyenne
- [ ] Page critique : histogramme vertical des notes (barres colorées, notes 1→10 en abscisse)
- [ ] Page critique : liste des coups de cœur (notes ≥9), clic → fiche livre
- [ ] Fiche livre → nom critique affiché en bleu → clic → page critique
- [ ] Recherche → résultat type `critique` → clic → page critique
- [ ] CI verte ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)