### PR TITLE
feat(palmares): vitesse de lecture (#93)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/LmelpApp.kt
+++ b/app/src/main/java/com/lmelp/mobile/LmelpApp.kt
@@ -59,9 +59,9 @@ class LmelpApp : Application() {
             database.avisCritiquesDao()
         )
     }
-    val livresRepository by lazy { LivresRepository(database.livresDao()) }
-    val critiquesRepository by lazy { CritiquesRepository(database.critiquesDao()) }
     val palmaresRepository by lazy { PalmaresRepository(database.palmaresDao(), database.calibreHorsMasqueDao()) }
+    val livresRepository by lazy { LivresRepository(database.livresDao(), palmaresRepository) }
+    val critiquesRepository by lazy { CritiquesRepository(database.critiquesDao()) }
     val recommendationsRepository by lazy { RecommendationsRepository(database.recommendationsDao()) }
     val searchRepository by lazy { SearchRepository(database.searchDao()) }
     val metadataRepository by lazy { MetadataRepository(database.metadataDao()) }

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -62,7 +62,8 @@ data class LivreDetailUi(
     val calibreInLibrary: Boolean = false,
     val calibreLu: Boolean = false,
     val calibreRating: Double? = null,
-    val dateLecture: String? = null
+    val dateLecture: String? = null,
+    val joursLecture: Int? = null
 )
 
 data class PalmaresUi(
@@ -187,7 +188,8 @@ data class MonPalmaresItemUi(
     val calibreRating: Double?,
     val dateLecture: String?,
     val livreId: String? = null,
-    val urlCover: String? = null
+    val urlCover: String? = null,
+    val joursLecture: Int? = null
 )
 
 data class DbInfoUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
@@ -6,7 +6,8 @@ import com.lmelp.mobile.data.model.AvisUi
 import com.lmelp.mobile.data.model.LivreDetailUi
 
 class LivresRepository(
-    private val livresDao: LivresDao
+    private val livresDao: LivresDao,
+    private val palmaresRepository: PalmaresRepository? = null
 ) {
 
     suspend fun getLivreDetail(livreId: String): LivreDetailUi? {
@@ -43,6 +44,10 @@ class LivresRepository(
                 )
             }
 
+        val joursLecture = if (livre.calibreLu == 1 && livre.dateLecture != null)
+            palmaresRepository?.getJoursLecturePourLivre(livre.id)
+        else null
+
         return LivreDetailUi(
             id = livre.id,
             titre = livre.titre,
@@ -56,7 +61,8 @@ class LivresRepository(
             calibreInLibrary = livre.calibreInLibrary == 1,
             calibreLu = livre.calibreLu == 1,
             calibreRating = livre.calibreRating,
-            dateLecture = livre.dateLecture
+            dateLecture = livre.dateLecture,
+            joursLecture = joursLecture
         )
     }
 }

--- a/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
@@ -57,6 +57,51 @@ class PalmaresRepository(
         )
     }
 
+    /**
+     * Retourne le nombre de jours de lecture pour un livre donné (null si non calculable :
+     * 1er livre lu, pas de date_lecture, ou livreId inconnu).
+     */
+    suspend fun getJoursLecturePourLivre(livreId: String): Int? {
+        val masque = palmaresDao.getMonPalmares().map { it.toItemUi() }
+        val horsMasque = horsMasqueDao?.getAll().orEmpty().map { it.toItemUi() }
+        val avecDate = (masque + horsMasque)
+            .filter { it.dateLecture != null }
+            .sortedBy { it.dateLecture }
+        val idx = avecDate.indexOfFirst { it.id == livreId }
+        if (idx <= 0) return null  // non trouvé ou 1er livre
+        return calculerJoursEntre(avecDate[idx - 1].dateLecture!!, avecDate[idx].dateLecture!!)
+    }
+
+    /** Fusionne livres Masque + hors Masque et calcule la vitesse de lecture (jours entre livres consécutifs). */
+    suspend fun getMonPalmaresUnifieParVitesse(ascendant: Boolean = true): List<MonPalmaresItemUi> {
+        val masque = palmaresDao.getMonPalmares().map { it.toItemUi() }
+        val horsMasque = horsMasqueDao?.getAll().orEmpty().map { it.toItemUi() }
+        return calculerVitesse(masque + horsMasque, ascendant)
+    }
+
+    private fun calculerVitesse(items: List<MonPalmaresItemUi>, ascendant: Boolean): List<MonPalmaresItemUi> {
+        val avecDate = items
+            .filter { it.dateLecture != null }
+            .sortedBy { it.dateLecture }
+        val resultat = mutableListOf<MonPalmaresItemUi>()
+        for (i in 1 until avecDate.size) {
+            val prev = avecDate[i - 1]
+            val curr = avecDate[i]
+            val jours = calculerJoursEntre(prev.dateLecture!!, curr.dateLecture!!)
+            resultat.add(curr.copy(joursLecture = jours))
+        }
+        return if (ascendant)
+            resultat.sortedWith(compareBy({ it.joursLecture ?: Int.MAX_VALUE }, { it.titre }))
+        else
+            resultat.sortedWith(compareByDescending<MonPalmaresItemUi> { it.joursLecture ?: 0 }.thenBy { it.titre })
+    }
+
+    private fun calculerJoursEntre(date1: String, date2: String): Int {
+        val d1 = java.time.LocalDate.parse(date1)
+        val d2 = java.time.LocalDate.parse(date2)
+        return java.time.temporal.ChronoUnit.DAYS.between(d1, d2).toInt()
+    }
+
     /** Fusionne livres Masque + hors Masque en une liste unifiée triée par date. */
     suspend fun getMonPalmaresUnifieParDate(): List<MonPalmaresItemUi> {
         val masque = palmaresDao.getMonPalmaresParDate().map { it.toItemUi() }

--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
@@ -173,8 +173,12 @@ fun LivreDetailContent(
                         )
                     }
                     if (livre.calibreLu && livre.dateLecture != null) {
+                        val dateTxt = buildString {
+                            append("Lu le ${formatDateLong(livre.dateLecture)}")
+                            livre.joursLecture?.let { append(" (${it}j)") }
+                        }
                         Text(
-                            text = "Lu le ${formatDateLong(livre.dateLecture)}",
+                            text = dateTxt,
                             style = MaterialTheme.typography.labelSmall,
                             color = androidx.compose.ui.graphics.Color(0xFF2E7D32),
                             modifier = Modifier.padding(top = 4.dp)

--- a/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
@@ -140,6 +140,17 @@ fun PalmaresContent(
                     onClick = { onSetMonPalmaresTriMode(MonPalmaresTriMode.DATE_LECTURE) },
                     label = { Text("Date lecture ↓") }
                 )
+                FilterChip(
+                    selected = uiState.monPalmaresTriMode == MonPalmaresTriMode.VITESSE_ASC ||
+                               uiState.monPalmaresTriMode == MonPalmaresTriMode.VITESSE_DESC,
+                    onClick = { onSetMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC) },
+                    label = {
+                        Text(
+                            if (uiState.monPalmaresTriMode == MonPalmaresTriMode.VITESSE_DESC)
+                                "Vitesse ↑" else "Vitesse ↓"
+                        )
+                    }
+                )
                 Spacer(modifier = Modifier.weight(1f))
                 FilterChip(
                     selected = uiState.showHorsMasque,
@@ -253,12 +264,21 @@ fun MonPalmaresCard(item: MonPalmaresItemUi, onLivreClick: (String) -> Unit) {
                     )
                 }
             }
-            item.calibreRating?.let {
-                Text(
-                    text = "${it.toInt()}/10",
-                    style = MaterialTheme.typography.titleMedium,
-                    color = Color(0xFF2E7D32)
-                )
+            Column(horizontalAlignment = Alignment.End) {
+                item.joursLecture?.let {
+                    Text(
+                        text = "${it}j",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+                item.calibreRating?.let {
+                    Text(
+                        text = "${it.toInt()}/10",
+                        style = MaterialTheme.typography.titleMedium,
+                        color = Color(0xFF2E7D32)
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/lmelp/mobile/viewmodel/PalmaresViewModel.kt
+++ b/app/src/main/java/com/lmelp/mobile/viewmodel/PalmaresViewModel.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 enum class PalmaresMode { CRITIQUES, PERSONNEL }
-enum class MonPalmaresTriMode { NOTE_PERSO, DATE_LECTURE }
+enum class MonPalmaresTriMode { NOTE_PERSO, DATE_LECTURE, VITESSE_ASC, VITESSE_DESC }
 
 data class PalmaresUiState(
     val isLoading: Boolean = false,
@@ -62,7 +62,13 @@ class PalmaresViewModel(
     }
 
     fun setMonPalmaresTriMode(tri: MonPalmaresTriMode) {
-        _uiState.update { it.copy(monPalmaresTriMode = tri) }
+        val current = _uiState.value.monPalmaresTriMode
+        val newMode = when {
+            tri == MonPalmaresTriMode.VITESSE_ASC && current == MonPalmaresTriMode.VITESSE_ASC -> MonPalmaresTriMode.VITESSE_DESC
+            tri == MonPalmaresTriMode.VITESSE_ASC && current == MonPalmaresTriMode.VITESSE_DESC -> MonPalmaresTriMode.VITESSE_ASC
+            else -> tri
+        }
+        _uiState.update { it.copy(monPalmaresTriMode = newMode) }
         loadPalmares()
     }
 
@@ -91,6 +97,8 @@ class PalmaresViewModel(
                         val allItems = when (state.monPalmaresTriMode) {
                             MonPalmaresTriMode.NOTE_PERSO -> repository.getMonPalmaresUnifieParNote()
                             MonPalmaresTriMode.DATE_LECTURE -> repository.getMonPalmaresUnifieParDate()
+                            MonPalmaresTriMode.VITESSE_ASC -> repository.getMonPalmaresUnifieParVitesse(ascendant = true)
+                            MonPalmaresTriMode.VITESSE_DESC -> repository.getMonPalmaresUnifieParVitesse(ascendant = false)
                         }
                         val monPalmares = if (state.showHorsMasque) allItems
                             else allItems.filter { it.livreId != null }

--- a/app/src/test/java/com/lmelp/mobile/JoursLectureLivreDetailTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/JoursLectureLivreDetailTest.kt
@@ -1,0 +1,132 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.CalibreHorsMasqueDao
+import com.lmelp.mobile.data.db.MonPalmaresRow
+import com.lmelp.mobile.data.db.PalmaresDao
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
+import com.lmelp.mobile.data.repository.PalmaresRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests TDD pour l'affichage du nb de jours de lecture dans la fiche livre (issue #93 extension).
+ *
+ * getJoursLecturePourLivre(livreId) retourne le nb de jours calculé pour ce livre
+ * dans la chronologie de tous les livres lus (Masque + hors Masque).
+ */
+class JoursLectureLivreDetailTest {
+
+    private fun makeRow(livreId: String, dateLecture: String?) = MonPalmaresRow(
+        livreId = livreId,
+        titre = "Titre $livreId",
+        auteurNom = null,
+        noteMoyenne = 7.0,
+        nbAvis = 2,
+        nbCritiques = 2,
+        calibreRating = null,
+        urlCover = null,
+        dateLecture = dateLecture
+    )
+
+    private fun makeHm(id: String, dateLecture: String?) = CalibreHorsMasqueEntity(
+        id = id,
+        titre = "HM $id",
+        auteurNom = null,
+        calibreRating = null,
+        dateLecture = dateLecture
+    )
+
+    // --- Test 1 : retourne les jours corrects pour un livreId Masque ---
+
+    @Test
+    fun `getJoursLecturePourLivre_retourne_jours_livre_masque`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeRow("A", "2024-01-01"),
+                makeRow("B", "2024-01-15")
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val jours = repo.getJoursLecturePourLivre("B")
+
+        assertEquals(14, jours)
+    }
+
+    // --- Test 2 : le 1er livre lu retourne null (pas de référence) ---
+
+    @Test
+    fun `getJoursLecturePourLivre_premier_livre_retourne_null`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeRow("A", "2024-01-01"),
+                makeRow("B", "2024-02-01")
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val jours = repo.getJoursLecturePourLivre("A")
+
+        assertNull(jours)
+    }
+
+    // --- Test 3 : livre sans date_lecture retourne null ---
+
+    @Test
+    fun `getJoursLecturePourLivre_livre_sans_date_retourne_null`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeRow("A", "2024-01-01"),
+                makeRow("B", null)
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val jours = repo.getJoursLecturePourLivre("B")
+
+        assertNull(jours)
+    }
+
+    // --- Test 4 : livre non trouvé retourne null ---
+
+    @Test
+    fun `getJoursLecturePourLivre_livre_inconnu_retourne_null`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(makeRow("A", "2024-01-01"))
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val jours = repo.getJoursLecturePourLivre("INCONNU")
+
+        assertNull(jours)
+    }
+
+    // --- Test 5 : livre hors Masque participe au calcul d'un livre Masque ---
+
+    @Test
+    fun `getJoursLecturePourLivre_hors_masque_participe_au_calcul`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        // Livre hors Masque lu le 01/01
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(makeRow("masque1", "2024-01-21"))
+        )
+        whenever(horsMasqueDao.getAll()).thenReturn(
+            listOf(makeHm("hm1", "2024-01-01"))
+        )
+        val repo = PalmaresRepository(palmaresDao, horsMasqueDao)
+
+        // masque1 lu 20j après hm1
+        val jours = repo.getJoursLecturePourLivre("masque1")
+
+        assertEquals(20, jours)
+    }
+}

--- a/app/src/test/java/com/lmelp/mobile/VitesseLectureRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/VitesseLectureRepositoryTest.kt
@@ -1,0 +1,224 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.CalibreHorsMasqueDao
+import com.lmelp.mobile.data.db.MonPalmaresRow
+import com.lmelp.mobile.data.db.PalmaresDao
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
+import com.lmelp.mobile.data.repository.PalmaresRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests TDD pour la vitesse de lecture dans Mon Palmarès (issue #93).
+ *
+ * La vitesse = nb de jours entre deux lectures consécutives (ordre chronologique).
+ * Le 1er livre lu n'a pas de vitesse calculable → exclu.
+ * Calcul sur TOUS les livres (Masque + hors Masque), filtre affichage séparé.
+ */
+class VitesseLectureRepositoryTest {
+
+    private fun makeMonPalmaresRow(
+        livreId: String,
+        titre: String = "Titre $livreId",
+        dateLecture: String? = null,
+        calibreRating: Double? = null
+    ) = MonPalmaresRow(
+        livreId = livreId,
+        titre = titre,
+        auteurNom = null,
+        noteMoyenne = 7.0,
+        nbAvis = 2,
+        nbCritiques = 2,
+        calibreRating = calibreRating,
+        urlCover = null,
+        dateLecture = dateLecture
+    )
+
+    private fun makeHorsMasque(
+        id: String,
+        titre: String = "HM $id",
+        dateLecture: String? = null,
+        calibreRating: Double? = null
+    ) = CalibreHorsMasqueEntity(
+        id = id,
+        titre = titre,
+        auteurNom = null,
+        calibreRating = calibreRating,
+        dateLecture = dateLecture
+    )
+
+    // --- Test 1 : calcul de base sur deux livres consécutifs ---
+
+    @Test
+    fun `calcul_vitesse_deux_livres_chronologiques`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-01-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-01-15")
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParVitesse(ascendant = true)
+
+        // Livre A = 1er → exclu. Livre B = 14 jours après A
+        assertEquals(1, result.size)
+        assertEquals("B", result[0].id)
+        assertEquals(14, result[0].joursLecture)
+    }
+
+    // --- Test 2 : le 1er livre chronologique est exclu ---
+
+    @Test
+    fun `premier_livre_exclu_pas_de_vitesse`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-03-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-04-01"),
+                makeMonPalmaresRow("C", dateLecture = "2024-05-01")
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParVitesse(ascendant = true)
+
+        // A est exclu. B et C ont une vitesse.
+        assertEquals(2, result.size)
+        val ids = result.map { it.id }
+        assertTrue("A ne doit pas apparaître", "A" !in ids)
+        assertTrue("B doit apparaître", "B" in ids)
+        assertTrue("C doit apparaître", "C" in ids)
+    }
+
+    // --- Test 3 : un livre hors Masque participe au calcul ---
+
+    @Test
+    fun `calcul_inclut_hors_masque_pour_calcul`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        // Livre Masque lu le 01/01
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(makeMonPalmaresRow("masque1", dateLecture = "2024-01-01"))
+        )
+        // Livre hors Masque lu 10 jours plus tard
+        whenever(horsMasqueDao.getAll()).thenReturn(
+            listOf(makeHorsMasque("hm1", dateLecture = "2024-01-11"))
+        )
+        val repo = PalmaresRepository(palmaresDao, horsMasqueDao)
+
+        val result = repo.getMonPalmaresUnifieParVitesse(ascendant = true)
+
+        // masque1 = 1er → exclu. hm1 = 10 jours après masque1
+        assertEquals(1, result.size)
+        assertEquals("hm1", result[0].id)
+        assertEquals(10, result[0].joursLecture)
+    }
+
+    // --- Test 4 : livres sans date_lecture exclus ---
+
+    @Test
+    fun `livres_sans_date_exclus`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-01-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-01-10"),
+                makeMonPalmaresRow("sansDate", dateLecture = null)
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParVitesse(ascendant = true)
+
+        // A exclu (1er), B inclus (9j), sansDate exclu (pas de date)
+        assertEquals(1, result.size)
+        assertEquals("B", result[0].id)
+        assertEquals(9, result[0].joursLecture)
+    }
+
+    // --- Test 5 : tri ascendant → rapides en premier ---
+
+    @Test
+    fun `tri_ascendant_rapides_en_premier`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-01-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-01-21"),  // 20 jours
+                makeMonPalmaresRow("C", dateLecture = "2024-01-26")   // 5 jours
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParVitesse(ascendant = true)
+
+        // A exclu. C (5j) avant B (20j)
+        assertEquals(2, result.size)
+        assertEquals("C", result[0].id)
+        assertEquals(5, result[0].joursLecture)
+        assertEquals("B", result[1].id)
+        assertEquals(20, result[1].joursLecture)
+    }
+
+    // --- Test 6 : tri descendant → lents en premier ---
+
+    @Test
+    fun `tri_descendant_lents_en_premier`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-01-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-01-21"),  // 20 jours
+                makeMonPalmaresRow("C", dateLecture = "2024-01-26")   // 5 jours
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParVitesse(ascendant = false)
+
+        // A exclu. B (20j) avant C (5j)
+        assertEquals(2, result.size)
+        assertEquals("B", result[0].id)
+        assertEquals(20, result[0].joursLecture)
+        assertEquals("C", result[1].id)
+        assertEquals(5, result[1].joursLecture)
+    }
+
+    // --- Test 7 : liste vide si moins de 2 livres avec date ---
+
+    @Test
+    fun `moins_de_deux_livres_avec_date_retourne_liste_vide`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(makeMonPalmaresRow("A", dateLecture = "2024-01-01"))
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParVitesse(ascendant = true)
+
+        assertTrue("Avec 1 seul livre, la liste doit être vide", result.isEmpty())
+    }
+
+    // --- Test 8 : joursLecture est null par défaut (hors mode vitesse) ---
+
+    @Test
+    fun `joursLecture_null_dans_autres_modes_de_tri`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(makeMonPalmaresRow("A", dateLecture = "2024-01-01"))
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParNote()
+
+        assertEquals(1, result.size)
+        assertNull("joursLecture doit être null hors mode vitesse", result[0].joursLecture)
+    }
+}

--- a/app/src/test/java/com/lmelp/mobile/VitesseLectureViewModelTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/VitesseLectureViewModelTest.kt
@@ -1,0 +1,191 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.CalibreHorsMasqueDao
+import com.lmelp.mobile.data.db.MonPalmaresRow
+import com.lmelp.mobile.data.db.PalmaresDao
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
+import com.lmelp.mobile.data.repository.PalmaresRepository
+import com.lmelp.mobile.viewmodel.MonPalmaresTriMode
+import com.lmelp.mobile.viewmodel.PalmaresMode
+import com.lmelp.mobile.viewmodel.PalmaresViewModel
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests TDD pour la vitesse de lecture dans le ViewModel (issue #93).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class VitesseLectureViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun makeMonPalmaresRow(
+        livreId: String,
+        dateLecture: String? = null
+    ) = MonPalmaresRow(
+        livreId = livreId,
+        titre = "Titre $livreId",
+        auteurNom = null,
+        noteMoyenne = 7.0,
+        nbAvis = 2,
+        nbCritiques = 2,
+        calibreRating = 8.0,
+        urlCover = null,
+        dateLecture = dateLecture
+    )
+
+    private fun makeHorsMasque(
+        id: String,
+        dateLecture: String? = null
+    ) = CalibreHorsMasqueEntity(
+        id = id,
+        titre = "HM $id",
+        auteurNom = null,
+        calibreRating = 7.0,
+        dateLecture = dateLecture
+    )
+
+    // --- Test 1 : clic sur Vitesse → mode VITESSE_ASC ---
+
+    @Test
+    fun `clic_vitesse_passe_en_mode_VITESSE_ASC`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-01-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-02-01")
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+        val viewModel = PalmaresViewModel(repo)
+        advanceUntilIdle()
+
+        viewModel.setPalmaresMode(PalmaresMode.PERSONNEL)
+        advanceUntilIdle()
+
+        viewModel.setMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertEquals(MonPalmaresTriMode.VITESSE_ASC, state.monPalmaresTriMode)
+        assertFalse(state.isLoading)
+    }
+
+    // --- Test 2 : reclique sur Vitesse → bascule en VITESSE_DESC ---
+
+    @Test
+    fun `reclique_vitesse_bascule_VITESSE_DESC`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-01-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-02-01")
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+        val viewModel = PalmaresViewModel(repo)
+        advanceUntilIdle()
+
+        viewModel.setPalmaresMode(PalmaresMode.PERSONNEL)
+        advanceUntilIdle()
+
+        // 1er clic → VITESSE_ASC
+        viewModel.setMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC)
+        advanceUntilIdle()
+        assertEquals(MonPalmaresTriMode.VITESSE_ASC, viewModel.uiState.value.monPalmaresTriMode)
+
+        // 2e clic → VITESSE_DESC
+        viewModel.setMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC)
+        advanceUntilIdle()
+        assertEquals(MonPalmaresTriMode.VITESSE_DESC, viewModel.uiState.value.monPalmaresTriMode)
+    }
+
+    // --- Test 3 : 3e clic sur Vitesse → revient VITESSE_ASC ---
+
+    @Test
+    fun `troisieme_clic_vitesse_revient_VITESSE_ASC`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(
+                makeMonPalmaresRow("A", dateLecture = "2024-01-01"),
+                makeMonPalmaresRow("B", dateLecture = "2024-02-01")
+            )
+        )
+        val repo = PalmaresRepository(palmaresDao)
+        val viewModel = PalmaresViewModel(repo)
+        advanceUntilIdle()
+
+        viewModel.setPalmaresMode(PalmaresMode.PERSONNEL)
+        advanceUntilIdle()
+
+        viewModel.setMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC)
+        advanceUntilIdle()
+        viewModel.setMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC)
+        advanceUntilIdle()
+        viewModel.setMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC)
+        advanceUntilIdle()
+
+        assertEquals(MonPalmaresTriMode.VITESSE_ASC, viewModel.uiState.value.monPalmaresTriMode)
+    }
+
+    // --- Test 4 : filtre hors Masque s'applique après calcul ---
+
+    @Test
+    fun `filtre_horsMasque_sApplique_apres_calcul_vitesse`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+
+        // Livre Masque (1er lu → exclu du calcul)
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(makeMonPalmaresRow("masque1", dateLecture = "2024-01-01"))
+        )
+        // Livre hors Masque (2e lu → a une vitesse calculable)
+        whenever(horsMasqueDao.getAll()).thenReturn(
+            listOf(makeHorsMasque("hm1", dateLecture = "2024-02-01"))
+        )
+
+        val repo = PalmaresRepository(palmaresDao, horsMasqueDao)
+        val viewModel = PalmaresViewModel(repo)
+        advanceUntilIdle()
+
+        viewModel.setPalmaresMode(PalmaresMode.PERSONNEL)
+        advanceUntilIdle()
+
+        // Avec hors Masque visible
+        viewModel.setMonPalmaresTriMode(MonPalmaresTriMode.VITESSE_ASC)
+        advanceUntilIdle()
+        val avecHorsMasque = viewModel.uiState.value.monPalmares
+        assertTrue("hm1 doit apparaître quand showHorsMasque=true",
+            avecHorsMasque.any { it.id == "hm1" })
+
+        // Sans hors Masque (filter livreId != null)
+        viewModel.setShowHorsMasque(false)
+        advanceUntilIdle()
+        val sansHorsMasque = viewModel.uiState.value.monPalmares
+        assertTrue("hm1 doit disparaître quand showHorsMasque=false",
+            sansHorsMasque.none { it.id == "hm1" })
+    }
+}

--- a/docs/claude/memory/260414-1730-issue93-vitesse-lecture.md
+++ b/docs/claude/memory/260414-1730-issue93-vitesse-lecture.md
@@ -1,0 +1,76 @@
+# Issue #93 — Vitesse de lecture dans Mon Palmarès + fiche livre
+
+## Fonctionnalité ajoutée
+
+Ajout d'un 3e mode de tri "Vitesse lecture" dans **Mon Palmarès**, et affichage du nombre de jours de lecture dans la **fiche livre**.
+
+---
+
+## Logique de calcul
+
+- Tous les livres lus (Masque + hors Masque) sont triés chronologiquement par `date_lecture`
+- Pour le livre N : `joursLecture = date_N - date_(N-1)` en jours (via `java.time.LocalDate` + `ChronoUnit.DAYS`)
+- Le 1er livre chronologique est **exclu** (pas de référence précédente → `null`)
+- Les livres sans `date_lecture` sont exclus du calcul et de l'affichage vitesse
+- Le filtre "Hors Masque" s'applique à l'**affichage uniquement** — le calcul utilise toujours tous les livres
+
+---
+
+## Fichiers modifiés
+
+### `app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt`
+- `MonPalmaresItemUi` : nouveau champ `joursLecture: Int? = null`
+- `LivreDetailUi` : nouveau champ `joursLecture: Int? = null`
+
+### `app/src/main/java/com/lmelp/mobile/viewmodel/PalmaresViewModel.kt`
+- `MonPalmaresTriMode` étendu : `VITESSE_ASC`, `VITESSE_DESC`
+- `setMonPalmaresTriMode()` : logique de bascule — si VITESSE_ASC déjà actif → VITESSE_DESC, et vice-versa
+- `loadPalmares()` : deux nouveaux cas dans le `when`
+
+### `app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt`
+- `getMonPalmaresUnifieParVitesse(ascendant: Boolean)` : fusionne Masque + hors Masque, calcule les jours, trie
+- `getJoursLecturePourLivre(livreId: String): Int?` : retourne les jours pour un livre spécifique (pour la fiche livre)
+- `calculerVitesse()` (private) : logique centrale de calcul
+- `calculerJoursEntre()` (private) : `java.time.LocalDate.parse()` sans formatter (ISO par défaut)
+
+### `app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt`
+- Nouveau `FilterChip` "Vitesse ↓" / "Vitesse ↑" (label dynamique selon direction)
+- `MonPalmaresCard` : colonne droite affichant `"${joursLecture}j"` en gris au-dessus de la note
+
+### `app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt`
+- Injection optionnelle de `PalmaresRepository? = null`
+- `getLivreDetail()` : appelle `getJoursLecturePourLivre()` si le livre est lu et a une date
+
+### `app/src/main/java/com/lmelp/mobile/LmelpApp.kt`
+- `palmaresRepository` déplacé **avant** `livresRepository` (dépendance lazy)
+- `livresRepository` instancié avec `palmaresRepository` en paramètre
+
+### `app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt`
+- Ligne "Lu le XX/XX/XXXX" enrichie avec `" (Xj)"` quand `joursLecture != null`
+
+---
+
+## Tests ajoutés (17 nouveaux tests)
+
+### `VitesseLectureRepositoryTest.kt` (8 tests)
+- Calcul de base 2 livres, exclusion 1er livre, participation hors Masque, livres sans date, tri ASC, tri DESC, moins de 2 livres → vide, joursLecture null hors mode vitesse
+
+### `VitesseLectureViewModelTest.kt` (4 tests)
+- Clic → VITESSE_ASC, reclique → VITESSE_DESC, 3e clic → retour ASC, filtre hors Masque après calcul
+
+### `JoursLectureLivreDetailTest.kt` (5 tests)
+- Jours corrects pour livre Masque, 1er livre → null, livre sans date → null, livre inconnu → null, hors Masque participe au calcul d'un livre Masque
+
+---
+
+## Pattern architectural clé
+
+`LivresRepository` injecte `PalmaresRepository` optionnellement pour enrichir `LivreDetailUi` sans coupler fortement les deux repositories. Le paramètre par défaut `= null` préserve la compatibilité des tests existants de `LivresRepository`.
+
+---
+
+## Points d'attention
+
+- `java.time.LocalDate.parse(dateStr)` fonctionne sans formatter car les dates sont déjà en format ISO (`YYYY-MM-DD`)
+- La bascule ASC/DESC se fait en passant toujours `VITESSE_ASC` à `setMonPalmaresTriMode()` — le ViewModel gère la bascule interne
+- L'ordre `palmaresRepository` avant `livresRepository` dans `LmelpApp.kt` est critique (lazy dependency)

--- a/docs/user/.nav.yml
+++ b/docs/user/.nav.yml
@@ -2,3 +2,4 @@ nav:
   - Contenu: README.md
   - Mise à jour d'un épisode: mise_a_jour_episode.md
   - Épingler des livres en cours de lecture: epingler_livres.md
+  - Vitesse de lecture: vitesse_lecture.md

--- a/docs/user/vitesse_lecture.md
+++ b/docs/user/vitesse_lecture.md
@@ -1,0 +1,33 @@
+# Vitesse de lecture dans Mon Palmarès
+
+L'écran **Mon Palmarès** propose un tri par **Vitesse de lecture** : afficher vos livres lus du plus rapidement au plus lentement (ou l'inverse).
+
+## Comment ça marche
+
+Le nombre de jours affiché représente le temps entre la fin du livre précédent et la fin de ce livre, dans l'ordre chronologique de vos lectures. Il est calculé sur l'ensemble de vos livres lus — qu'ils soient discutés au Masque ou non.
+
+**Exemple :** si vous avez terminé *Livre A* le 1er janvier et *Livre B* le 15 janvier, *Livre B* affichera **14j**.
+
+!!! note "Premier livre"
+    Le tout premier livre que vous avez lu n'affiche pas de durée — il n'y a pas de lecture précédente comme référence.
+
+## Utiliser le tri Vitesse
+
+Dans l'onglet **Mon Palmarès** :
+
+1. Appuyer sur **Vitesse ↓** pour voir les livres lus le plus rapidement en premier
+2. Appuyer une nouvelle fois sur **Vitesse ↑** pour inverser l'ordre (les plus lents en premier)
+
+Seuls les livres dont la durée est calculable apparaissent dans ce mode (livres avec une date de fin de lecture).
+
+## Filtre Hors Masque
+
+Le bouton **Hors Masque** fonctionne normalement : il masque à l'affichage les livres non discutés au Masque. Mais ces livres participent quand même au calcul des durées — c'est votre rythme de lecture global qui compte.
+
+## Durée dans la fiche livre
+
+Quand vous ouvrez la fiche d'un livre que vous avez lu, la ligne de date de lecture affiche également la durée :
+
+> Lu le 15/01/2024 **(14j)**
+
+Cette information apparaît automatiquement si la durée peut être calculée (pas pour le 1er livre lu).


### PR DESCRIPTION
## Summary

- Ajout d'un 3e tri **Vitesse ↓/↑** dans Mon Palmarès : nombre de jours entre lectures consécutives (Masque + hors Masque)
- 1er clic = rapides en premier, 2e clic = lents en premier
- Affichage du nombre de jours dans chaque carte (`14j`) et dans la fiche livre (`Lu le 15/01/2024 (14j)`)
- Le calcul utilise tous les livres lus ; le filtre Hors Masque s'applique à l'affichage uniquement

## Test plan

- [x] Tests unitaires : 17 nouveaux tests (repository, viewmodel, fiche livre) — tous GREEN
- [x] Lint : clean
- [x] mkdocs build --strict : OK
- [x] CI : success
- [x] Test manuel sur device validé par l'utilisateur

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)