### PR TITLE
fix(search): corriger syntaxe MATCH FTS4 invalide (#96)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -302,16 +302,27 @@ Voir [docs/data-schema.md](docs/data-schema.md) pour le schéma complet.
 
 ## Recherche full-text
 
-SQLite FTS5 pour la recherche :
+SQLite **FTS4** pour la recherche (attention : c'est FTS4, pas FTS5) :
 
 ```sql
--- Table virtuelle FTS5
-CREATE VIRTUAL TABLE search_index USING fts5(
-    type,        -- 'emission' | 'livre' | 'auteur' | 'critique'
-    ref_id,      -- ID de l'entité référencée
-    content,     -- Texte indexé
-    tokenize = 'unicode61 remove_diacritics 2'  -- Insensible aux accents
+-- Table virtuelle FTS4
+CREATE VIRTUAL TABLE search_index USING fts4(
+    type,            -- 'emission' | 'livre' | 'auteur' | 'critique'
+    ref_id,          -- ID de l'entité référencée
+    content,         -- Texte normalisé sans accents (indexé)
+    display_content, -- Texte original avec accents (affiché dans l'UI)
+    notindexed=type,
+    notindexed=ref_id,
+    notindexed=display_content
 );
+```
+
+⚠️ **Syntaxe MATCH FTS4** : le MATCH s'applique au nom de la table, pas à un alias de colonne :
+```sql
+-- ✅ CORRECT
+WHERE search_index MATCH ?
+-- ❌ INVALIDE (search_index est le nom de la table, pas une colonne)
+WHERE si.search_index MATCH ?
 ```
 
 ## Conventions de nommage

--- a/app/src/main/java/com/lmelp/mobile/data/repository/SearchRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/SearchRepository.kt
@@ -24,7 +24,7 @@ class SearchRepository(
                l.url_cover AS url_cover
                FROM search_index si
                LEFT JOIN livres l ON (si.type = 'livre' AND l.id = si.ref_id)
-               WHERE si.search_index MATCH ? AND si.type IN ('livre', 'auteur', 'critique')
+               WHERE search_index MATCH ? AND si.type IN ('livre', 'auteur', 'critique')
                LIMIT 50""",
             arrayOf(ftsQuery)
         )

--- a/app/src/test/java/com/lmelp/mobile/SearchRepositoryTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/SearchRepositoryTest.kt
@@ -1,20 +1,25 @@
 package com.lmelp.mobile
 
+import androidx.sqlite.db.SupportSQLiteQuery
 import com.lmelp.mobile.data.db.SearchDao
 import com.lmelp.mobile.data.db.SearchRow
 import com.lmelp.mobile.data.repository.SearchRepository
 import kotlinx.coroutines.test.runTest
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
-import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 
 class SearchRepositoryTest {
 
     @Test
     fun `search returns empty list for blank query`() = runTest {
-        val dao = mock(SearchDao::class.java)
+        val dao = mock<SearchDao>()
         val repo = SearchRepository(dao)
         val result = repo.search("")
         assertTrue(result.isEmpty())
@@ -22,9 +27,57 @@ class SearchRepositoryTest {
 
     @Test
     fun `search returns empty list for single char query`() = runTest {
-        val dao = mock(SearchDao::class.java)
+        val dao = mock<SearchDao>()
         val repo = SearchRepository(dao)
         val result = repo.search("a")
         assertTrue(result.isEmpty())
+    }
+
+    /**
+     * Reproduit le bug #96 : la requête SQL utilise `si.search_index MATCH ?`
+     * ce qui est invalide — `search_index` est le nom de la table, pas une colonne.
+     * La syntaxe FTS4 correcte est `search_index MATCH ?`.
+     *
+     * RED : ce test échoue avant le fix.
+     */
+    @Test
+    fun `la requete SQL utilise search_index MATCH sans prefixe de colonne`() = runTest {
+        val dao = mock<SearchDao>()
+        whenever(dao.searchRaw(any())).thenReturn(emptyList())
+        val repo = SearchRepository(dao)
+
+        repo.search("hamlet")
+
+        val captor = argumentCaptor<SupportSQLiteQuery>()
+        verify(dao).searchRaw(captor.capture())
+        val sql = captor.firstValue.sql
+
+        assertFalse(
+            "La requête SQL ne doit PAS contenir 'si.search_index MATCH' (colonne invalide FTS4), mais contient : $sql",
+            sql.contains("si.search_index MATCH", ignoreCase = true)
+        )
+        assertTrue(
+            "La requête SQL doit contenir 'search_index MATCH' (sans préfixe de colonne), mais est : $sql",
+            sql.contains("search_index MATCH", ignoreCase = true)
+        )
+    }
+
+    @Test
+    fun `search mappe displayContent comme content dans SearchResultUi`() = runTest {
+        val dao = mock<SearchDao>()
+        val fakeRow = SearchRow(
+            type = "livre",
+            refId = "abc123",
+            content = "hamlet contenu indexé",
+            displayContent = "Hamlet (affichage)",
+            urlCover = null
+        )
+        whenever(dao.searchRaw(any())).thenReturn(listOf(fakeRow))
+        val repo = SearchRepository(dao)
+
+        val results = repo.search("hamlet")
+
+        assertEquals(1, results.size)
+        assertEquals("Hamlet (affichage)", results[0].content)
     }
 }

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -18,7 +18,7 @@
 │  scripts/export_mongo_to_sqlite.py                              │
 │    ├── Exporte les collections                                  │
 │    ├── Précalcule palmarès + recommandations SVD                │
-│    ├── Construit index FTS5 (recherche full-text)               │
+│    ├── Construit index FTS4 (recherche full-text)               │
 │    ├── Croise avec Calibre (onkindle, lu/non lu, rating)        │
 │    └── Écrit lmelp.db (SQLite)                                  │
 │         │                                                       │
@@ -42,7 +42,7 @@
 │    ├── Émissions                                                │
 │    ├── Palmarès                                                 │
 │    ├── Critiques                                                │
-│    ├── Recherche (FTS5)                                         │
+│    ├── Recherche (FTS4)                                         │
 │    ├── Recommandations                                          │
 │    └── Sur ma liseuse (OnKindle)                                │
 │                                                                 │
@@ -103,7 +103,7 @@
 │    ├── CritiquesDao                                             │
 │    ├── AvisDao                                                  │
 │    ├── OnKindleDao                                              │
-│    └── SearchDao (FTS5)                                         │
+│    └── SearchDao (FTS4)                                         │
 │                                                                 │
 │  SQLite : app/src/main/assets/lmelp.db                          │
 │    └── Copié dans /data/data/.../databases/ au 1er lancement   │
@@ -182,14 +182,16 @@ ORDER BY note_moyenne DESC
 - Top N recommandations précalculées et stockées dans `recommendations`
 - Reproductible depuis `back-office-lmelp` (même algorithme)
 
-### Index FTS5
+### Index FTS4
 ```sql
 -- Construit à l'export pour recherche instantanée
-INSERT INTO search_index(type, ref_id, content) VALUES
-  ('emission', id, titre || ' ' || description),
-  ('livre', id, titre || ' ' || auteur_nom || ' ' || editeur),
-  ('critique', id, nom),
-  ('auteur', id, nom);
+-- content = texte normalisé sans accents (indexé)
+-- display_content = texte original avec accents (affiché)
+INSERT INTO search_index(type, ref_id, content, display_content) VALUES
+  ('emission', id, normalize(titre || ' ' || description), titre || ' ' || description),
+  ('livre', id, normalize(titre || ' ' || auteur_nom || ' ' || editeur), titre),
+  ('critique', id, normalize(nom), nom),
+  ('auteur', id, normalize(nom), nom);
 ```
 
 ## Taille estimée

--- a/docs/claude/memory/260422-2020-issue96-bug-recherche-sql-fts4.md
+++ b/docs/claude/memory/260422-2020-issue96-bug-recherche-sql-fts4.md
@@ -1,0 +1,52 @@
+# Issue #96 — Bug recherche : erreur SQL FTS4
+
+## Contexte
+
+La recherche plante avec une erreur SQL car la requête référence une colonne invalide dans une table virtuelle FTS4.
+
+## Cause racine
+
+Dans `app/src/main/java/com/lmelp/mobile/data/repository/SearchRepository.kt:27`, la requête SQL utilisait :
+
+```sql
+WHERE si.search_index MATCH ?
+```
+
+`search_index` est le **nom de la table virtuelle FTS4**, pas une colonne. La syntaxe `si.search_index` (préfixe d'alias de table + nom de table) est invalide en SQLite FTS4.
+
+## Fix
+
+Remplacer par :
+
+```sql
+WHERE search_index MATCH ?
+```
+
+En FTS4, le MATCH s'applique à la table directement (pas à une colonne), même quand la table est jointe via un alias.
+
+## Point important : FTS4, pas FTS5
+
+La table virtuelle `search_index` est créée en **FTS4** dans `scripts/export_mongo_to_sqlite.py:178` :
+
+```sql
+CREATE VIRTUAL TABLE IF NOT EXISTS search_index USING fts4(...)
+```
+
+La documentation dans `CLAUDE.md` mentionne FTS5 — c'est une erreur de documentation. La réalité du code est FTS4.
+
+## Tests TDD ajoutés
+
+Dans `app/src/test/java/com/lmelp/mobile/SearchRepositoryTest.kt` :
+
+- `la requete SQL utilise search_index MATCH sans prefixe de colonne` — utilise `argumentCaptor` Mockito pour capturer la `SupportSQLiteQuery` passée au DAO et vérifier que le SQL ne contient pas `si.search_index MATCH` mais bien `search_index MATCH`
+- `search mappe displayContent comme content dans SearchResultUi` — vérifie que le champ `displayContent` (texte affiché) est bien utilisé comme `content` dans le `SearchResultUi` (et non le champ `content` brut qui sert à l'index FTS)
+
+## Pattern de test pour capturer une requête SQL
+
+```kotlin
+val captor = argumentCaptor<SupportSQLiteQuery>()
+verify(dao).searchRaw(captor.capture())
+val sql = captor.firstValue.sql
+assertFalse(sql.contains("si.search_index MATCH", ignoreCase = true))
+assertTrue(sql.contains("search_index MATCH", ignoreCase = true))
+```

--- a/docs/dev/data-schema.md
+++ b/docs/dev/data-schema.md
@@ -188,17 +188,26 @@ CREATE TABLE avis_critiques (
 );
 ```
 
-### `search_index` (FTS5)
+### `search_index` (FTS4)
 
-**Index full-text** pour la recherche. Table virtuelle SQLite FTS5.
+**Index full-text** pour la recherche. Table virtuelle SQLite FTS4.
 
 ```sql
-CREATE VIRTUAL TABLE search_index USING fts5(
-    type,       -- 'emission' | 'livre' | 'auteur' | 'critique'
-    ref_id,     -- ID de l'entité référencée (TEXT)
-    content,    -- Contenu indexé (titre + auteur + description...)
-    tokenize = 'unicode61 remove_diacritics 2'
+CREATE VIRTUAL TABLE search_index USING fts4(
+    type,            -- 'emission' | 'livre' | 'auteur' | 'critique'
+    ref_id,          -- ID de l'entité référencée (TEXT)
+    content,         -- Texte normalisé sans accents (indexé pour MATCH)
+    display_content, -- Texte original avec accents (affiché dans l'UI)
+    notindexed=type,
+    notindexed=ref_id,
+    notindexed=display_content
 );
+```
+
+⚠️ **Syntaxe MATCH** : s'applique au nom de la table, pas à un alias de colonne :
+```sql
+WHERE search_index MATCH ?   -- ✅ correct
+WHERE si.search_index MATCH ?  -- ❌ invalide (search_index est le nom de la table)
 ```
 
 **Contenu indexé par type :**


### PR DESCRIPTION
## Summary

- Corrige le bug #96 : la recherche plantait avec une erreur SQL car `si.search_index MATCH ?` est invalide — `search_index` est le nom de la table virtuelle FTS4, pas une colonne
- Fix : remplacer par `search_index MATCH ?` dans `SearchRepository`
- Corrige la documentation (FTS5 → FTS4) dans `CLAUDE.md`, `docs/architecture.md` et `docs/dev/data-schema.md`

## Test plan

- [x] Test TDD RED ajouté (`la requete SQL utilise search_index MATCH sans prefixe de colonne`) — capture la requête via `argumentCaptor` Mockito
- [x] Test passe au GREEN après le fix
- [x] Suite complète de tests unitaires : OK
- [x] Lint : OK
- [x] CI/CD : OK
- [x] Test manuel sur device : recherche fonctionnelle

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)