### PR TITLE
feat(koreader): utiliser ko_finish/ko_start pour date_lecture et date_debut_lecture (#100)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,8 @@ build/
 # Debug SQLite exports (sauf la DB embarquée dans l'APK)
 /tmp/
 *.db
+*.db-shm
+*.db-wal
 !app/src/main/assets/lmelp.db
 !app/src/main/assets/*.db.sha256
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,6 +68,16 @@ repos:
               ui/sketchs/.*\.excalidraw
           )$
 
+  - repo: local
+    hooks:
+      - id: room-version-consistency
+        name: Room version consistency (LmelpDatabase.kt ↔ export script ↔ lmelp.db)
+        entry: python -m pytest tests/test_lmelp_db_integrity.py::TestVersionConsistance -q
+        language: python
+        additional_dependencies: [pytest]
+        pass_filenames: false
+        always_run: true
+
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 26.3.1
     hooks:

--- a/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/LivresDao.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Dao
 import androidx.room.Embedded
 import androidx.room.Query
+import androidx.room.RoomWarnings
 import com.lmelp.mobile.data.model.AvisEntity
 import com.lmelp.mobile.data.model.LivreEntity
 
@@ -35,7 +36,8 @@ data class LivreAvecCalibreRow(
     @ColumnInfo(name = "calibre_in_library", defaultValue = "0") val calibreInLibrary: Int = 0,
     @ColumnInfo(name = "calibre_lu", defaultValue = "0") val calibreLu: Int = 0,
     @ColumnInfo(name = "calibre_rating") val calibreRating: Double? = null,
-    @ColumnInfo(name = "date_lecture") val dateLecture: String? = null
+    @ColumnInfo(name = "date_lecture") val dateLecture: String? = null,
+    @ColumnInfo(name = "date_debut_lecture") val dateDebutLecture: String? = null
 )
 
 @Dao
@@ -50,7 +52,8 @@ interface LivresDao {
                COALESCE(p.calibre_in_library, 0) as calibre_in_library,
                COALESCE(p.calibre_lu, 0) as calibre_lu,
                p.calibre_rating,
-               p.date_lecture
+               p.date_lecture,
+               p.date_debut_lecture
         FROM livres l
         LEFT JOIN palmares p ON p.livre_id = l.id
         WHERE l.id = :id
@@ -64,6 +67,7 @@ interface LivresDao {
     """)
     suspend fun getLivresByEmission(emissionId: String): List<LivreEntity>
 
+    @SuppressWarnings(RoomWarnings.CURSOR_MISMATCH)
     @Query("""
         SELECT l.id, l.titre, l.auteur_id, l.auteur_nom, l.editeur,
                l.url_babelio, l.url_cover, l.created_at, l.updated_at,

--- a/app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt
@@ -35,7 +35,7 @@ import com.lmelp.mobile.data.model.RecommendationEntity
         OnKindleEntity::class,
         CalibreHorsMasqueEntity::class,
     ],
-    version = 6,
+    version = 7,
     exportSchema = false
 )
 abstract class LmelpDatabase : RoomDatabase() {

--- a/app/src/main/java/com/lmelp/mobile/data/db/PalmaresDao.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/db/PalmaresDao.kt
@@ -17,7 +17,8 @@ data class PalmaresFiltreAvecUrlRow(
     @ColumnInfo(name = "calibre_lu")      val calibreLu: Int = 0,
     @ColumnInfo(name = "calibre_rating")  val calibreRating: Double? = null,
     @ColumnInfo(name = "url_cover")       val urlCover: String?,
-    @ColumnInfo(name = "date_lecture")    val dateLecture: String? = null
+    @ColumnInfo(name = "date_lecture")    val dateLecture: String? = null,
+    @ColumnInfo(name = "date_debut_lecture") val dateDebutLecture: String? = null
 )
 
 data class PalmaresAvecUrlRow(
@@ -39,7 +40,8 @@ data class MonPalmaresRow(
     @ColumnInfo(name = "nb_critiques")    val nbCritiques: Int,
     @ColumnInfo(name = "calibre_rating")  val calibreRating: Double?,
     @ColumnInfo(name = "url_cover")       val urlCover: String?,
-    @ColumnInfo(name = "date_lecture")    val dateLecture: String?
+    @ColumnInfo(name = "date_lecture")    val dateLecture: String?,
+    @ColumnInfo(name = "date_debut_lecture") val dateDebutLecture: String? = null
 )
 
 @Dao
@@ -76,7 +78,7 @@ interface PalmaresDao {
     @Query("""
         SELECT p.rank, p.livre_id, p.titre, p.auteur_nom, p.note_moyenne,
                p.nb_avis, p.nb_critiques, p.calibre_in_library, p.calibre_lu, p.calibre_rating,
-               l.url_cover, p.date_lecture
+               l.url_cover, p.date_lecture, p.date_debut_lecture
         FROM palmares p
         LEFT JOIN livres l ON l.id = p.livre_id
         WHERE p.nb_avis >= 2
@@ -90,7 +92,7 @@ interface PalmaresDao {
 
     @Query("""
         SELECT p.livre_id, p.titre, p.auteur_nom, p.note_moyenne, p.nb_avis, p.nb_critiques,
-               p.calibre_rating, l.url_cover, p.date_lecture
+               p.calibre_rating, l.url_cover, p.date_lecture, p.date_debut_lecture
         FROM palmares p
         LEFT JOIN livres l ON l.id = p.livre_id
         WHERE p.calibre_lu = 1
@@ -103,7 +105,7 @@ interface PalmaresDao {
 
     @Query("""
         SELECT p.livre_id, p.titre, p.auteur_nom, p.note_moyenne, p.nb_avis, p.nb_critiques,
-               p.calibre_rating, l.url_cover, p.date_lecture
+               p.calibre_rating, l.url_cover, p.date_lecture, p.date_debut_lecture
         FROM palmares p
         LEFT JOIN livres l ON l.id = p.livre_id
         WHERE p.calibre_lu = 1

--- a/app/src/main/java/com/lmelp/mobile/data/model/Entities.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/Entities.kt
@@ -107,7 +107,8 @@ data class PalmaresEntity(
     @ColumnInfo(name = "calibre_in_library", defaultValue = "0") val calibreInLibrary: Int = 0,
     @ColumnInfo(name = "calibre_lu", defaultValue = "0") val calibreLu: Int = 0,
     @ColumnInfo(name = "calibre_rating") val calibreRating: Double? = null,
-    @ColumnInfo(name = "date_lecture") val dateLecture: String? = null
+    @ColumnInfo(name = "date_lecture") val dateLecture: String? = null,
+    @ColumnInfo(name = "date_debut_lecture") val dateDebutLecture: String? = null
 )
 
 @Entity(tableName = "recommendations")
@@ -180,7 +181,8 @@ data class CalibreHorsMasqueEntity(
     val titre: String,
     @ColumnInfo(name = "auteur_nom") val auteurNom: String?,
     @ColumnInfo(name = "calibre_rating") val calibreRating: Double?,
-    @ColumnInfo(name = "date_lecture") val dateLecture: String?
+    @ColumnInfo(name = "date_lecture") val dateLecture: String?,
+    @ColumnInfo(name = "date_debut_lecture") val dateDebutLecture: String? = null
 )
 
 @Entity(tableName = "db_metadata")

--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -63,6 +63,7 @@ data class LivreDetailUi(
     val calibreLu: Boolean = false,
     val calibreRating: Double? = null,
     val dateLecture: String? = null,
+    val dateDebutLecture: String? = null,
     val joursLecture: Int? = null
 )
 
@@ -187,6 +188,7 @@ data class MonPalmaresItemUi(
     val auteurNom: String?,
     val calibreRating: Double?,
     val dateLecture: String?,
+    val dateDebutLecture: String? = null,
     val livreId: String? = null,
     val urlCover: String? = null,
     val joursLecture: Int? = null

--- a/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/LivresRepository.kt
@@ -62,6 +62,7 @@ class LivresRepository(
             calibreLu = livre.calibreLu == 1,
             calibreRating = livre.calibreRating,
             dateLecture = livre.dateLecture,
+            dateDebutLecture = livre.dateDebutLecture,
             joursLecture = joursLecture
         )
     }

--- a/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
@@ -69,7 +69,9 @@ class PalmaresRepository(
             .sortedBy { it.dateLecture }
         val idx = avecDate.indexOfFirst { it.id == livreId }
         if (idx <= 0) return null  // non trouvé ou 1er livre
-        return calculerJoursEntre(avecDate[idx - 1].dateLecture!!, avecDate[idx].dateLecture!!)
+        val curr = avecDate[idx]
+        val dateDebut = curr.dateDebutLecture ?: avecDate[idx - 1].dateLecture!!
+        return calculerJoursEntre(dateDebut, curr.dateLecture!!)
     }
 
     /** Fusionne livres Masque + hors Masque et calcule la vitesse de lecture (jours entre livres consécutifs). */
@@ -87,7 +89,8 @@ class PalmaresRepository(
         for (i in 1 until avecDate.size) {
             val prev = avecDate[i - 1]
             val curr = avecDate[i]
-            val jours = calculerJoursEntre(prev.dateLecture!!, curr.dateLecture!!)
+            val dateDebut = curr.dateDebutLecture ?: prev.dateLecture!!
+            val jours = calculerJoursEntre(dateDebut, curr.dateLecture!!)
             resultat.add(curr.copy(joursLecture = jours))
         }
         return if (ascendant)
@@ -164,6 +167,7 @@ class PalmaresRepository(
         auteurNom = auteurNom,
         calibreRating = calibreRating,
         dateLecture = dateLecture,
+        dateDebutLecture = dateDebutLecture,
         livreId = livreId,
         urlCover = urlCover
     )
@@ -174,6 +178,7 @@ class PalmaresRepository(
         auteurNom = auteurNom,
         calibreRating = calibreRating,
         dateLecture = dateLecture,
+        dateDebutLecture = dateDebutLecture,
         livreId = null,
         urlCover = null
     )

--- a/docs/claude/memory/260510-1530-issue100-koreader-dates.md
+++ b/docs/claude/memory/260510-1530-issue100-koreader-dates.md
@@ -1,0 +1,71 @@
+---
+name: Issue #100 — KOReader dates dans Calibre
+description: Utiliser ko_finish/ko_start KOReader pour date_lecture et date_debut_lecture, avec conversion UTC→Europe/Paris
+type: project
+---
+
+## Contexte
+
+Issue #100 : utiliser les colonnes KOReader dans Calibre pour les dates de lecture, plutôt que le parsing regex du champ Commentaire.
+
+## Colonnes KOReader dans Calibre
+
+KOReader (plugin Calibre) ajoute des colonnes custom :
+- `custom_column_7` : `ko_start` (Date KOReader Started)
+- `custom_column_8` : `ko_finish` (Date KOReader Finished)
+
+Les IDs des colonnes sont récupérés dynamiquement depuis `custom_columns` (label = `ko_start` / `ko_finish`).
+
+## Bug UTC → heure locale
+
+**Problème critique** : KOReader stocke les dates en UTC. Les dates arrondies à minuit heure locale sont stockées à **22h00 UTC** (été, UTC+2) ou **23h00 UTC** (hiver, UTC+1). Extraire naïvement la partie date donne le jour précédent.
+
+**Fix** : `extract_date_koreader()` convertit le datetime UTC en `Europe/Paris` via `zoneinfo.ZoneInfo` avant d'extraire la date. Utilise `datetime.fromisoformat()` + `dt.astimezone()`.
+
+**Exemple concret** :
+- `ko_finish = "2026-05-08 22:00:00+00:00"` → date locale = **2026-05-09** ✓
+- Extraction naïve → `2026-05-08` ✗
+
+## Logique d'import dans le script
+
+Dans `import_calibre_data()` et `build_calibre_hors_masque_table()` :
+1. `date_lecture` = `extract_date_koreader(ko_finish)` si disponible, sinon `extract_date_lecture(commentaire)`
+2. `date_debut_lecture` = `extract_date_koreader(ko_start)` si disponible, sinon `None`
+
+## Vitesse de lecture (PalmaresRepository)
+
+`calculerVitesse()` et `getJoursLecturePourLivre()` :
+- Si `curr.dateDebutLecture` disponible → `jours = calculerJoursEntre(dateDebutLecture, dateLecture)`
+- Sinon fallback → `jours = calculerJoursEntre(prev.dateLecture, curr.dateLecture)`
+
+**Why:** `date_debut_lecture` donne le vrai début de lecture (KOReader), plus précis que la date de fin du livre précédent.
+
+## Schéma Android (Room version 6 → 7)
+
+Champs ajoutés :
+- `PalmaresEntity` : `date_debut_lecture TEXT`
+- `CalibreHorsMasqueEntity` : `date_debut_lecture TEXT`
+- `MonPalmaresRow`, `PalmaresFiltreAvecUrlRow` : `dateDebutLecture`
+- `LivreAvecCalibreRow` : `dateDebutLecture`
+- `LivreDetailUi`, `MonPalmaresItemUi` : `dateDebutLecture`
+
+Requêtes SQL mises à jour : `getMonPalmares()`, `getMonPalmaresParDate()`, `getPalmaresFiltresAvecUrl()`, `getLivreAvecCalibreById()`.
+
+## Protection contre désynchronisation Room version
+
+**Bug rencontré** : `LmelpDatabase.kt version=7` mais `PRAGMA user_version = 6` dans le script → Room détruit les tables → app vide.
+
+**Protections ajoutées** :
+
+1. `ROOM_VERSION = 7` comme constante dans `scripts/export_mongo_to_sqlite.py`
+2. `_check_room_version_consistency()` appelée au début de `main()` : lit `LmelpDatabase.kt` via regex et échoue si discordance → **bloque l'export avant de toucher à la DB**
+3. `TestVersionConsistance` dans `tests/test_lmelp_db_integrity.py` : vérifie `ROOM_VERSION == LmelpDatabase.kt version == lmelp.db user_version`
+4. Hook pre-commit `room-version-consistency` dans `.pre-commit-config.yaml`
+
+**Règle** : quand on incrémente `version=N` dans `LmelpDatabase.kt`, toujours mettre à jour `ROOM_VERSION` dans le script **avant** de regénérer `lmelp.db`.
+
+## Autres corrections dans cette session
+
+- `test_export_date_posterieure_a_derniere_emission_mongo` : comparaison par `.date()` (pas datetime) pour éviter l'échec quand export et émission sont le même jour mais à des heures différentes
+- `.gitignore` : ajout de `*.db-shm` et `*.db-wal` (fichiers WAL SQLite non versionnés)
+- `getLivresAvecCalibreByEmission()` : `@SuppressWarnings(RoomWarnings.CURSOR_MISMATCH)` car la requête ne retourne pas `date_lecture`/`date_debut_lecture` (non nécessaire pour l'affichage d'une émission)

--- a/docs/user/mise_a_jour_episode.md
+++ b/docs/user/mise_a_jour_episode.md
@@ -8,7 +8,7 @@
 >
 > ![](img/favicon_whisper.png) transcription de l'épisode
 >
-> ??? info "mode d'emploi"
+> ??? info "mode d'emploi - whisper"
 >     manuellement depuis une machine **GPU avec whisper** en fournissant le `.m4a` depuis `docker-lmelp/data/audios`, et en retour copie du fichier `.txt` dans `docker-lmelp/data/audios`
 >     ```bash
 >     # exemple en utilisant le PGX
@@ -16,6 +16,12 @@
 >     ```
 >
 > ![](img/favicon_lmelp-frontoffice.png) depuis **lmelp-frontoffice**:
+>
+> ??? info "mode d'emploi - copie transcription"
+>     ```bash
+>     # exemple en utilisant le PGX
+>     scp f279814@thinkstationpgx-d7ba.local:/home/f279814/git/whisper-docker/docker/data/transcriptions/2026/14007-10.05.2026-ITEMA_24506307-2026F4007S0130-NET_MFI_8DBE1787-617F-448E-8CE2-33512DAB177D-27-45c045c235ee8b70bf0e486024ad25c4.txt git/docker-lmelp/data/audios/2026
+>     ```
 >
 > - ![](img/telecharger_transcriptions.png) charge le fichier de transcription (gestion de cache) dans le champ transcription de l'épisode (mongo/episodes)
 >

--- a/docs/user/mise_a_jour_episode.md
+++ b/docs/user/mise_a_jour_episode.md
@@ -35,7 +35,7 @@
 > - ![](img/liaison_babelio.png) **Liaison Babelio** : pour lier les oeuvres / auteurs à leurs pages babelio respectives, ainsi que le lien vers la couverture de l'oeuvre.
 >  Note: cliquer sur **Livres sans lien Babelio** / **Auteurs sans lien Babelio** dans la zone Informations générales nous amène à cette page
 > - ![](img/emissions.png) **Emissions** : visu du resultat de l'émission structurée : toutes les oeuvres doivent aparaitre identifiées, notées
->  Note: cliquer sur **Emissions avec Problème** dans la zone Informations générales nous amène à cette page
+>  Note: cliquer sur **Episodes sans Emission** dans la zone Informations générales nous amène à cette page
 
 
 à l'issue de tout cela la base de données a été enrichie avec ce nouvel episode

--- a/scripts/export_mongo_to_sqlite.py
+++ b/scripts/export_mongo_to_sqlite.py
@@ -35,6 +35,34 @@ logger = logging.getLogger(__name__)
 
 MONGO_DB = "masque_et_la_plume"
 
+# Doit correspondre à @Database(version=N) dans LmelpDatabase.kt.
+# v7 : ajout date_debut_lecture dans palmares et calibre_hors_masque (issue #100)
+ROOM_VERSION = 7
+
+_LMELP_DATABASE_KT = (
+    Path(__file__).parent.parent
+    / "app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt"
+)
+
+
+def _check_room_version_consistency() -> None:
+    """Vérifie que ROOM_VERSION correspond à version=N dans LmelpDatabase.kt."""
+    if not _LMELP_DATABASE_KT.exists():
+        return  # hors devcontainer (CI sans Android SDK), on skip
+    text = _LMELP_DATABASE_KT.read_text()
+    m = re.search(r"version\s*=\s*(\d+)", text)
+    if not m:
+        raise SystemExit(
+            f"Impossible de lire la version Room dans {_LMELP_DATABASE_KT}"
+        )
+    kt_version = int(m.group(1))
+    if kt_version != ROOM_VERSION:
+        raise SystemExit(
+            f"ROOM_VERSION ({ROOM_VERSION}) dans le script d'export "
+            f"≠ version={kt_version} dans LmelpDatabase.kt.\n"
+            "Mettre à jour ROOM_VERSION dans ce script avant de regénérer lmelp.db."
+        )
+
 
 # ---------------------------------------------------------------------------
 # MongoDB helpers
@@ -161,7 +189,8 @@ CREATE TABLE IF NOT EXISTS palmares (
     calibre_in_library  INTEGER NOT NULL DEFAULT 0,
     calibre_lu          INTEGER NOT NULL DEFAULT 0,
     calibre_rating      REAL,
-    date_lecture        TEXT
+    date_lecture        TEXT,
+    date_debut_lecture  TEXT
 );
 
 CREATE TABLE IF NOT EXISTS recommendations (
@@ -210,7 +239,8 @@ CREATE TABLE IF NOT EXISTS calibre_hors_masque (
     titre          TEXT NOT NULL,
     auteur_nom     TEXT,
     calibre_rating REAL,
-    date_lecture   TEXT
+    date_lecture   TEXT,
+    date_debut_lecture TEXT
 );
 """
 
@@ -470,6 +500,7 @@ def compute_palmares(cur: sqlite3.Cursor) -> None:
 
 
 _DATE_LECTURE_RE = re.compile(r"\b(\d{2})/(\d{2})/(\d{4})\b")
+_DATE_KOREADER_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})")
 
 
 def extract_date_lecture(commentaire: str | None) -> str | None:
@@ -484,6 +515,30 @@ def extract_date_lecture(commentaire: str | None) -> str | None:
         day, month, year = m.group(1), m.group(2), m.group(3)
         return f"{year}-{month}-{day}"
     return None
+
+
+def extract_date_koreader(value: str | None) -> str | None:
+    """Extrait la date locale (Europe/Paris) depuis un champ datetime KOReader Calibre.
+
+    KOReader stocke les dates en UTC au format "YYYY-MM-DD HH:MM:SS+00:00".
+    Les dates arrondies à minuit heure locale sont stockées à 22h00 UTC (UTC+2 en été)
+    ou 23h00 UTC (UTC+1 en hiver) — la conversion UTC→Europe/Paris est donc nécessaire
+    pour obtenir la date correcte.
+    """
+    if not value:
+        return None
+    if not _DATE_KOREADER_RE.match(str(value)):
+        return None
+    try:
+        import zoneinfo
+        from datetime import datetime
+
+        dt = datetime.fromisoformat(str(value))
+        if dt.tzinfo is not None:
+            dt = dt.astimezone(zoneinfo.ZoneInfo("Europe/Paris"))
+        return dt.strftime("%Y-%m-%d")
+    except Exception:
+        return None
 
 
 def _normalize_title(titre: str) -> str:
@@ -548,6 +603,23 @@ def import_calibre_data(
         else:
             logger.warning("  Colonne 'text' (Commentaire) non trouvée dans Calibre")
 
+        # Trouve les colonnes KOReader (ko_finish = date fin, ko_start = date début)
+        ko_finish_col_id: int | None = None
+        row = cal_cur.execute(
+            "SELECT id FROM custom_columns WHERE label = 'ko_finish'"
+        ).fetchone()
+        if row:
+            ko_finish_col_id = row["id"]
+            logger.info(f"  Calibre 'ko_finish' column id: {ko_finish_col_id}")
+
+        ko_start_col_id: int | None = None
+        row = cal_cur.execute(
+            "SELECT id FROM custom_columns WHERE label = 'ko_start'"
+        ).fetchone()
+        if row:
+            ko_start_col_id = row["id"]
+            logger.info(f"  Calibre 'ko_start' column id: {ko_start_col_id}")
+
         # Charge les livres Calibre (avec filtre bibliothèque virtuelle si fourni)
         if virtual_library_tag:
             cal_cur.execute(
@@ -603,9 +675,16 @@ def import_calibre_data(
             if rating_row and rating_row["rating"] is not None:
                 calibre_rating = float(rating_row["rating"])
 
-            # Date de lecture (extraite du champ Commentaire custom_column_3)
+            # Date de fin de lecture : KOReader ko_finish en priorité, sinon Commentaire
             date_lecture: str | None = None
-            if comment_col_id is not None:
+            if ko_finish_col_id is not None:
+                ko_row = cal_cur.execute(
+                    f"SELECT value FROM custom_column_{ko_finish_col_id} WHERE book = ?",
+                    (calibre_id,),
+                ).fetchone()
+                if ko_row:
+                    date_lecture = extract_date_koreader(ko_row["value"])
+            if date_lecture is None and comment_col_id is not None:
                 comment_row = cal_cur.execute(
                     f"SELECT value FROM custom_column_{comment_col_id} WHERE book = ?",
                     (calibre_id,),
@@ -613,11 +692,28 @@ def import_calibre_data(
                 if comment_row:
                     date_lecture = extract_date_lecture(comment_row["value"])
 
+            # Date de début de lecture : KOReader ko_start
+            date_debut_lecture: str | None = None
+            if ko_start_col_id is not None:
+                ko_row = cal_cur.execute(
+                    f"SELECT value FROM custom_column_{ko_start_col_id} WHERE book = ?",
+                    (calibre_id,),
+                ).fetchone()
+                if ko_row:
+                    date_debut_lecture = extract_date_koreader(ko_row["value"])
+
             cur.execute(
                 """UPDATE palmares
-                   SET calibre_in_library = 1, calibre_lu = ?, calibre_rating = ?, date_lecture = ?
+                   SET calibre_in_library = 1, calibre_lu = ?, calibre_rating = ?,
+                       date_lecture = ?, date_debut_lecture = ?
                    WHERE livre_id = ?""",
-                (calibre_lu, calibre_rating, date_lecture, livre_id),
+                (
+                    calibre_lu,
+                    calibre_rating,
+                    date_lecture,
+                    date_debut_lecture,
+                    livre_id,
+                ),
             )
             matched += 1
 
@@ -646,7 +742,7 @@ def build_calibre_hors_masque_table(
         cal_con.row_factory = sqlite3.Row
         cal_cur = cal_con.cursor()
 
-        # Trouve les colonnes personnalisées (read, text/Commentaire)
+        # Trouve les colonnes personnalisées (read, text/Commentaire, KOReader)
         read_col_id: int | None = None
         row = cal_cur.execute(
             "SELECT id FROM custom_columns WHERE label = 'read'"
@@ -660,6 +756,20 @@ def build_calibre_hors_masque_table(
         ).fetchone()
         if row:
             comment_col_id = row["id"]
+
+        ko_finish_col_id: int | None = None
+        row = cal_cur.execute(
+            "SELECT id FROM custom_columns WHERE label = 'ko_finish'"
+        ).fetchone()
+        if row:
+            ko_finish_col_id = row["id"]
+
+        ko_start_col_id: int | None = None
+        row = cal_cur.execute(
+            "SELECT id FROM custom_columns WHERE label = 'ko_start'"
+        ).fetchone()
+        if row:
+            ko_start_col_id = row["id"]
 
         # Charge les livres Calibre (avec filtre bibliothèque virtuelle si fourni)
         if virtual_library_tag:
@@ -737,9 +847,16 @@ def build_calibre_hors_masque_table(
             if rating_row and rating_row["rating"] is not None:
                 calibre_rating = float(rating_row["rating"])
 
-            # Date de lecture
+            # Date de fin de lecture : KOReader ko_finish en priorité, sinon Commentaire
             date_lecture: str | None = None
-            if comment_col_id is not None:
+            if ko_finish_col_id is not None:
+                ko_row = cal_cur.execute(
+                    f"SELECT value FROM custom_column_{ko_finish_col_id} WHERE book = ?",
+                    (cal_id,),
+                ).fetchone()
+                if ko_row:
+                    date_lecture = extract_date_koreader(ko_row["value"])
+            if date_lecture is None and comment_col_id is not None:
                 comment_row = cal_cur.execute(
                     f"SELECT value FROM custom_column_{comment_col_id} WHERE book = ?",
                     (cal_id,),
@@ -747,11 +864,28 @@ def build_calibre_hors_masque_table(
                 if comment_row:
                     date_lecture = extract_date_lecture(comment_row["value"])
 
+            # Date de début de lecture : KOReader ko_start
+            date_debut_lecture: str | None = None
+            if ko_start_col_id is not None:
+                ko_row = cal_cur.execute(
+                    f"SELECT value FROM custom_column_{ko_start_col_id} WHERE book = ?",
+                    (cal_id,),
+                ).fetchone()
+                if ko_row:
+                    date_debut_lecture = extract_date_koreader(ko_row["value"])
+
             cur.execute(
                 """INSERT OR REPLACE INTO calibre_hors_masque
-                   (id, titre, auteur_nom, calibre_rating, date_lecture)
-                   VALUES (?, ?, ?, ?, ?)""",
-                (norm, titre, auteur_nom, calibre_rating, date_lecture),
+                   (id, titre, auteur_nom, calibre_rating, date_lecture, date_debut_lecture)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    norm,
+                    titre,
+                    auteur_nom,
+                    calibre_rating,
+                    date_lecture,
+                    date_debut_lecture,
+                ),
             )
             seen_norms.add(norm)
             inserted += 1
@@ -1224,9 +1358,7 @@ def write_metadata(cur: sqlite3.Cursor) -> None:
     ]
     cur.executemany("INSERT OR REPLACE INTO db_metadata VALUES (?,?)", metadata)
 
-    # user_version = version du schéma Room — doit correspondre à @Database(version=N) dans LmelpDatabase.kt
-    # v3 : ajout table onkindle (issue #52)
-    cur.execute("PRAGMA user_version = 6")
+    cur.execute(f"PRAGMA user_version = {ROOM_VERSION}")
 
     logger.info(
         f"  Metadata: version={version}, date={now.strftime('%Y-%m-%d')}, "
@@ -1339,6 +1471,8 @@ def main(
     if verify:
         verify_database(Path(verify))
         return
+
+    _check_room_version_consistency()
 
     output_path = Path(output)
 

--- a/tests/test_koreader_date_extraction.py
+++ b/tests/test_koreader_date_extraction.py
@@ -1,0 +1,53 @@
+"""
+Tests TDD pour l'extraction des dates KOReader depuis Calibre.
+
+KOReader stocke les dates en UTC :
+  "2026-05-08 22:00:00+00:00"
+
+On convertit en heure locale (Europe/Paris) avant d'extraire la date YYYY-MM-DD,
+car 22h UTC = minuit heure française (UTC+2 en été) → la date locale est le 09/05.
+
+Fallback sur extract_date_lecture(commentaire) si KOReader indisponible.
+"""
+
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import export_mongo_to_sqlite as script  # noqa: E402
+
+
+extract_date_koreader = script.extract_date_koreader
+
+
+class TestExtractDateKoreader:
+    def test_date_utc_converti_en_heure_locale(self):
+        # 22h UTC = 00h00 heure française (UTC+2 en été) → date locale = 2026-05-09
+        assert extract_date_koreader("2026-05-08 22:00:00+00:00") == "2026-05-09"
+
+    def test_date_iso_avec_microsecondes(self):
+        # 10h41 UTC = 12h41 heure française → même date
+        assert extract_date_koreader("2026-05-09 10:41:10.361000+00:00") == "2026-05-09"
+
+    def test_date_utc_heure_elevee_pas_de_changement(self):
+        # 12h00 UTC = 14h00 heure française → même date
+        assert extract_date_koreader("2025-08-01 12:00:00+00:00") == "2025-08-01"
+
+    def test_date_utc_hiver_22h(self):
+        # En hiver UTC+1 : 22h UTC = 23h locale → même date
+        assert extract_date_koreader("2025-12-15 22:00:00+00:00") == "2025-12-15"
+
+    def test_date_utc_hiver_23h(self):
+        # En hiver UTC+1 : 23h UTC = 00h locale le lendemain
+        assert extract_date_koreader("2025-12-15 23:00:00+00:00") == "2025-12-16"
+
+    def test_none_si_none(self):
+        assert extract_date_koreader(None) is None
+
+    def test_none_si_vide(self):
+        assert extract_date_koreader("") is None
+
+    def test_none_si_format_invalide(self):
+        assert extract_date_koreader("pas une date") is None

--- a/tests/test_lmelp_db_integrity.py
+++ b/tests/test_lmelp_db_integrity.py
@@ -22,7 +22,7 @@ qui nécessitent l'option --calibre-db lors de l'export.
 
 import os
 import sqlite3
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 
 import pytest
@@ -164,12 +164,65 @@ class TestFraicheurDB:
         latest_mongo = mongo_db.emissions.find_one({}, sort=[("date", -1)])
         assert latest_mongo is not None, "Aucune émission dans MongoDB"
 
-        export_date = datetime.fromisoformat(export_date_str[0]).replace(tzinfo=UTC)
-        latest_mongo_date = latest_mongo["date"].replace(tzinfo=UTC)
+        export_date = datetime.fromisoformat(export_date_str[0]).date()
+        latest_mongo_date = latest_mongo["date"].date()
 
         assert export_date >= latest_mongo_date, (
             f"lmelp.db périmé : export_date={export_date_str[0]} mais "
-            f"dernière émission MongoDB={latest_mongo_date.date()} "
+            f"dernière émission MongoDB={latest_mongo_date} "
             f"(id={latest_mongo['_id']}).\n"
             "Regénérer avec : python scripts/export_mongo_to_sqlite.py --force"
+        )
+
+
+class TestVersionConsistance:
+    """
+    Vérifie que PRAGMA user_version dans lmelp.db correspond à la version Room
+    déclarée dans LmelpDatabase.kt.
+
+    Cause de régression connue (issue #100) : oublier de mettre à jour
+    PRAGMA user_version dans le script d'export après avoir incrémenté version=N
+    dans LmelpDatabase.kt. Room détecte la discordance, détruit les tables via
+    fallbackToDestructiveMigration() et crée un schéma vide → app vide.
+    """
+
+    LMELP_DATABASE_KT = Path(__file__).parent.parent / (
+        "app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt"
+    )
+    EXPORT_SCRIPT = Path(__file__).parent.parent / "scripts/export_mongo_to_sqlite.py"
+
+    def _room_version(self) -> int:
+        import re
+
+        text = self.LMELP_DATABASE_KT.read_text()
+        m = re.search(r"version\s*=\s*(\d+)", text)
+        assert m, f"Impossible de lire la version Room dans {self.LMELP_DATABASE_KT}"
+        return int(m.group(1))
+
+    def _script_version(self) -> int:
+        import re
+
+        text = self.EXPORT_SCRIPT.read_text()
+        m = re.search(r"^ROOM_VERSION\s*=\s*(\d+)", text, re.MULTILINE)
+        assert m, f"Impossible de lire ROOM_VERSION dans {self.EXPORT_SCRIPT}"
+        return int(m.group(1))
+
+    def test_user_version_db_egale_room_version(self, db):
+        """PRAGMA user_version de lmelp.db doit égaler version=N dans LmelpDatabase.kt."""
+        db_version = db.execute("PRAGMA user_version").fetchone()[0]
+        room_version = self._room_version()
+        assert db_version == room_version, (
+            f"lmelp.db user_version={db_version} ≠ LmelpDatabase.kt version={room_version}.\n"
+            "Room va détruire les tables (fallbackToDestructiveMigration) → app vide.\n"
+            "Regénérer avec : python scripts/export_mongo_to_sqlite.py --force"
+        )
+
+    def test_script_version_egale_room_version(self):
+        """PRAGMA user_version dans le script d'export doit égaler version=N dans LmelpDatabase.kt."""
+        script_version = self._script_version()
+        room_version = self._room_version()
+        assert script_version == room_version, (
+            f"export_mongo_to_sqlite.py PRAGMA user_version={script_version} "
+            f"≠ LmelpDatabase.kt version={room_version}.\n"
+            "Mettre à jour PRAGMA user_version dans le script et regénérer lmelp.db."
         )


### PR DESCRIPTION
## Summary

- Extrait `date_lecture` depuis `ko_finish` (KOReader Finished) en priorité, fallback sur parsing commentaire
- Extrait `date_debut_lecture` depuis `ko_start` (KOReader Started), utilisé pour le calcul de vitesse de lecture
- Convertit les dates UTC KOReader en heure locale **Europe/Paris** avant extraction — KOReader arrondit à minuit local, stocké à 22h/23h UTC selon heure d'été/hiver
- Ajoute `ROOM_VERSION = 7` comme constante + vérification de cohérence au lancement du script (protège contre l'app vide si on oublie de synchroniser)
- Room version 6 → 7 (`date_debut_lecture` dans `palmares` et `calibre_hors_masque`)
- `PalmaresRepository.calculerVitesse()` utilise `dateDebutLecture` si disponible, sinon fallback sur `dateLecture` du livre précédent

## Test plan

- [x] 54 tests Python passent (`pytest tests/ -q`)
- [x] `TestVersionConsistance` : vérifie cohérence `ROOM_VERSION` ↔ `LmelpDatabase.kt` ↔ `lmelp.db`
- [x] `TestExtractDateKoreader` : 8 tests dont conversion UTC→Paris été/hiver
- [x] Build Android OK (`./gradlew assembleDebug`)
- [x] Lint Android OK (`./gradlew lint`)
- [x] CI verte (Python 3.11 + 3.12 + Android + pre-commit)
- [x] Testé sur Pixel 9 Pro — dates de lecture corrigées (Le lièvre : 08/05 → 09/05)
- [x] Hook pre-commit `room-version-consistency` bloque si désynchronisation

🤖 Generated with [Claude Code](https://claude.ai/claude-code)