### PR TITLE
fix(adb): arrêter l'app avant le push ADB et supprimer les fichiers WAL (#101)

### DIFF
--- a/scripts/docker_export_and_push.sh
+++ b/scripts/docker_export_and_push.sh
@@ -107,6 +107,16 @@ if [[ "$IS_DEBUGGABLE" -eq 0 ]]; then
     die "L'app installée n'est pas en mode debug — run-as non disponible.\nInstallez le build debug : scripts/build.sh && scripts/deploy.sh"
 fi
 
+info "Arrêt de l'app avant le remplacement de la base..."
+$ADB shell am force-stop "$APP_PACKAGE"
+sleep 1
+
+# Room utilise le mode WAL (Write-Ahead Logging) : lmelp.db-shm et lmelp.db-wal
+# doivent être supprimés avant de remplacer lmelp.db, sinon SQLite détecte une
+# incohérence DB/WAL → erreur "no such table: search_index" → rollback (issue #101).
+info "Suppression des fichiers WAL résiduels..."
+$ADB shell run-as "$APP_PACKAGE" rm -f databases/lmelp.db-shm databases/lmelp.db-wal || true
+
 info "Copie dans le répertoire privé de l'app..."
 $ADB shell run-as "$APP_PACKAGE" cp "$TMP_REMOTE" databases/lmelp.db
 
@@ -117,8 +127,6 @@ $ADB shell rm -f "$TMP_REMOTE"
 # 6. Redémarrage de l'app
 # ---------------------------------------------------------------------------
 info "Redémarrage de l'app..."
-$ADB shell am force-stop "$APP_PACKAGE"
-sleep 1
 $ADB shell am start -n "${APP_PACKAGE}/.MainActivity" || true
 
 echo ""


### PR DESCRIPTION
## Summary

- **Cause** : Room utilise le mode WAL (Write-Ahead Logging) — 3 fichiers : `lmelp.db`, `lmelp.db-shm`, `lmelp.db-wal`. En remplaçant `lmelp.db` pendant que l'app tourne, SQLite détectait une incohérence entre la nouvelle DB et l'ancien WAL → erreur `no such table: search_index` → rollback vers l'ancienne DB au redémarrage suivant.
- **Fix** : dans `docker_export_and_push.sh`, déplacer le `force-stop` **avant** le push, et supprimer les fichiers WAL résiduels avant de copier la nouvelle DB.

Séquence corrigée :
1. `force-stop` → Room ferme proprement et fusionne le WAL dans `lmelp.db`
2. Suppression de `lmelp.db-shm` et `lmelp.db-wal`
3. Copie de la nouvelle `lmelp.db`
4. `am start`

## Test plan

- [ ] Merger sur main → CI publie automatiquement `ghcr.io/castorfou/lmelp-mobile-export:latest`
- [ ] Sur le laptop : `docker compose pull && docker compose up -d lmelp-export`
- [ ] Lancer `lmelp-update-mobile.sh` avec le téléphone branché
- [ ] Vérifier que la recherche fonctionne immédiatement (sans erreur `no such table`)
- [ ] Vérifier que quitter/relancer l'app ne provoque pas de rollback

🤖 Generated with [Claude Code](https://claude.ai/claude-code)