### PR TITLE
feat(palmares): afficher la note du Masque dans Mon Palmarès (#107)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -191,7 +191,8 @@ data class MonPalmaresItemUi(
     val dateDebutLecture: String? = null,
     val livreId: String? = null,
     val urlCover: String? = null,
-    val joursLecture: Int? = null
+    val joursLecture: Int? = null,
+    val noteMoyenne: Double? = null
 )
 
 data class DbInfoUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt
@@ -169,7 +169,8 @@ class PalmaresRepository(
         dateLecture = dateLecture,
         dateDebutLecture = dateDebutLecture,
         livreId = livreId,
-        urlCover = urlCover
+        urlCover = urlCover,
+        noteMoyenne = noteMoyenne
     )
 
     private fun CalibreHorsMasqueEntity.toItemUi() = MonPalmaresItemUi(

--- a/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt
@@ -279,6 +279,9 @@ fun MonPalmaresCard(item: MonPalmaresItemUi, onLivreClick: (String) -> Unit) {
                         color = Color(0xFF2E7D32)
                     )
                 }
+                item.noteMoyenne?.let {
+                    NoteBadge(note = it)
+                }
             }
         }
     }

--- a/app/src/test/java/com/lmelp/mobile/MonPalmaresNoteMasqueTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/MonPalmaresNoteMasqueTest.kt
@@ -1,0 +1,92 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.CalibreHorsMasqueDao
+import com.lmelp.mobile.data.db.MonPalmaresRow
+import com.lmelp.mobile.data.db.PalmaresDao
+import com.lmelp.mobile.data.model.CalibreHorsMasqueEntity
+import com.lmelp.mobile.data.model.MonPalmaresItemUi
+import com.lmelp.mobile.data.repository.PalmaresRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests TDD pour l'affichage de la note du Masque dans Mon Palmarès (issue #107).
+ *
+ * La note du Masque (noteMoyenne) doit être propagée depuis MonPalmaresRow
+ * vers MonPalmaresItemUi pour être affichée dans MonPalmaresCard.
+ * Les livres hors Masque n'ont pas de note Masque (noteMoyenne = null).
+ */
+class MonPalmaresNoteMasqueTest {
+
+    private fun makeMonPalmaresRow(
+        livreId: String,
+        noteMoyenne: Double = 7.5,
+        calibreRating: Double? = null,
+        dateLecture: String? = null
+    ) = MonPalmaresRow(
+        livreId = livreId,
+        titre = "Titre $livreId",
+        auteurNom = null,
+        noteMoyenne = noteMoyenne,
+        nbAvis = 3,
+        nbCritiques = 3,
+        calibreRating = calibreRating,
+        urlCover = null,
+        dateLecture = dateLecture
+    )
+
+    private fun makeHorsMasque(id: String, calibreRating: Double? = null) =
+        CalibreHorsMasqueEntity(
+            id = id,
+            titre = "HM $id",
+            auteurNom = null,
+            calibreRating = calibreRating,
+            dateLecture = null
+        )
+
+    @Test
+    fun `noteMoyenne propagee depuis MonPalmaresRow vers MonPalmaresItemUi`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(
+            listOf(makeMonPalmaresRow("livre1", noteMoyenne = 8.2, calibreRating = 9.0))
+        )
+        val repo = PalmaresRepository(palmaresDao)
+
+        val result = repo.getMonPalmaresUnifieParNote()
+
+        assertEquals(1, result.size)
+        assertEquals(8.2, result[0].noteMoyenne!!, 0.01)
+    }
+
+    @Test
+    fun `livre hors Masque a noteMoyenne null`() = runTest {
+        val palmaresDao = mock<PalmaresDao>()
+        val horsMasqueDao = mock<CalibreHorsMasqueDao>()
+        whenever(palmaresDao.getMonPalmares()).thenReturn(emptyList())
+        whenever(horsMasqueDao.getAll()).thenReturn(
+            listOf(makeHorsMasque("hm1", calibreRating = 8.0))
+        )
+        val repo = PalmaresRepository(palmaresDao, horsMasqueDao)
+
+        val result = repo.getMonPalmaresUnifieParNote()
+
+        assertEquals(1, result.size)
+        assertNull("Un livre hors Masque n'a pas de note Masque", result[0].noteMoyenne)
+    }
+
+    @Test
+    fun `MonPalmaresItemUi a noteMoyenne null par defaut`() {
+        val item = MonPalmaresItemUi(
+            id = "x",
+            titre = "Test",
+            auteurNom = null,
+            calibreRating = null,
+            dateLecture = null
+        )
+        assertNull(item.noteMoyenne)
+    }
+}

--- a/docs/claude/memory/260512-1400-issue107-note-masque-mon-palmares.md
+++ b/docs/claude/memory/260512-1400-issue107-note-masque-mon-palmares.md
@@ -1,0 +1,67 @@
+# Issue #107 — Afficher les notes du Masque dans Mon Palmarès
+
+## Problème
+
+Dans l'écran "Mon palmarès" (mode PERSONNEL), chaque carte livre affichait la note personnelle
+Calibre (`calibreRating`) mais **pas la note moyenne du Masque** (`noteMoyenne`).
+La donnée existait dans la base (`MonPalmaresRow.noteMoyenne`) mais était perdue à la conversion.
+
+## Cause : chaîne de données cassée à trois niveaux
+
+1. `MonPalmaresItemUi` n'avait pas de champ `noteMoyenne`
+2. `MonPalmaresRow.toItemUi()` dans `PalmaresRepository` ignorait `noteMoyenne` lors du mapping
+3. `MonPalmaresCard` dans `PalmaresScreen.kt` n'affichait pas la note du Masque
+
+## Corrections (3 fichiers)
+
+### 1. Modèle UI
+`app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt`
+
+Ajout du champ dans `MonPalmaresItemUi` :
+```kotlin
+val noteMoyenne: Double? = null
+```
+Nullable car les livres hors Masque (CalibreHorsMasque) ne figurent pas dans la table `palmares`.
+
+### 2. Repository
+`app/src/main/java/com/lmelp/mobile/data/repository/PalmaresRepository.kt`
+
+Dans `MonPalmaresRow.toItemUi()` — ajout :
+```kotlin
+noteMoyenne = noteMoyenne
+```
+La fonction `CalibreHorsMasqueEntity.toItemUi()` est inchangée → `noteMoyenne` reste `null` pour les livres hors Masque.
+
+### 3. Affichage
+`app/src/main/java/com/lmelp/mobile/ui/palmares/PalmaresScreen.kt`
+
+Dans `MonPalmaresCard`, dans la `Column(horizontalAlignment = Alignment.End)` existante — ajout :
+```kotlin
+item.noteMoyenne?.let {
+    NoteBadge(note = it)
+}
+```
+Réutilise le composable `NoteBadge` déjà utilisé dans `PalmaresCard`.
+
+## Rendu visuel
+
+```
+[couverture] Titre                    7j
+             Auteur                   8/10  ← note perso Calibre (vert)
+             Lu le 12/05/2026         7.5   ← note Masque (NoteBadge coloré)
+```
+Les livres hors Masque n'affichent pas de `NoteBadge`.
+
+## Tests TDD
+
+Fichier créé : `app/src/test/java/com/lmelp/mobile/MonPalmaresNoteMasqueTest.kt`
+
+3 tests :
+1. `noteMoyenne propagée depuis MonPalmaresRow vers MonPalmaresItemUi` — vérifie le mapping repository
+2. `livre hors Masque a noteMoyenne null` — vérifie `CalibreHorsMasqueEntity` mapping
+3. `MonPalmaresItemUi a noteMoyenne null par defaut` — vérifie la valeur par défaut
+
+## Pattern retenu
+
+`MonPalmaresItemUi` regroupe livres Masque (avec `noteMoyenne`) et hors Masque (sans).
+Utiliser des `Double?` nullable pour les champs propres au Masque — l'UI utilise `?.let` pour n'afficher que si présent.

--- a/docs/user/mon_palmares.md
+++ b/docs/user/mon_palmares.md
@@ -1,0 +1,24 @@
+# Mon Palmarès
+
+L'onglet **Mon Palmarès** affiche tous les livres que vous avez lus dans Calibre, qu'ils soient discutés au Masque ou non.
+
+## Colonnes affichées sur chaque carte
+
+| Colonne | Description |
+|---------|-------------|
+| Couverture | Miniature du livre (si disponible, pour les livres du Masque) |
+| Titre / Auteur | Titre et nom de l'auteur |
+| Date de lecture | Date à laquelle vous avez terminé le livre dans Calibre |
+| **xj** | Nombre de jours de lecture (voir [Vitesse de lecture](vitesse_lecture.md)) |
+| **x/10** | Votre note personnelle Calibre (en vert) |
+| Badge coloré | Note moyenne du Masque (uniquement pour les livres discutés au Masque) |
+
+## Tris disponibles
+
+- **Note ↓** — vos livres par note personnelle décroissante
+- **Date lecture ↓** — vos lectures les plus récentes en premier
+- **Vitesse ↓ / ↑** — du plus rapide au plus lent (ou l'inverse)
+
+## Filtre Hors Masque
+
+Le bouton **Hors Masque** affiche ou masque les livres que vous avez lus mais qui ne sont pas discutés au Masque. Ces livres n'ont pas de note Masque.


### PR DESCRIPTION
## Summary

- Ajout du champ `noteMoyenne` dans `MonPalmaresItemUi` (nullable — `null` pour les livres hors Masque)
- Propagation de `note_moyenne` depuis `MonPalmaresRow.toItemUi()` dans `PalmaresRepository`
- Affichage via `NoteBadge` dans `MonPalmaresCard` à côté de la note personnelle Calibre
- Documentation utilisateur : nouveau fichier `docs/user/mon_palmares.md`

## Test plan

- [x] 3 tests unitaires TDD dans `MonPalmaresNoteMasqueTest.kt` (propagation, livre hors Masque, valeur par défaut)
- [x] `./gradlew testDebugUnitTest` — BUILD SUCCESSFUL
- [x] `./gradlew lint` — BUILD SUCCESSFUL
- [x] `mkdocs build --strict` — BUILD SUCCESSFUL
- [x] CI/CD GitHub Actions — success
- [x] Test utilisateur sur téléphone — validé

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)