### PR TITLE
fix(liseuse): remettre la liste au début lors d'un changement de filtre ou tri (#103)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/ui/onkindle/OnKindleScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/onkindle/OnKindleScreen.kt
@@ -20,6 +20,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.PushPin
@@ -169,9 +171,13 @@ fun OnKindleContent(
             uiState.error != null -> ErrorMessage(uiState.error)
             uiState.livres.isEmpty() -> EmptyState("Aucun livre sur la liseuse")
             else -> {
+                val listState = rememberLazyListState()
+                LaunchedEffect(uiState.afficherLus, uiState.afficherNonLus, uiState.triMode) {
+                    listState.scrollToItem(0)
+                }
                 val pinnedLivres = uiState.livres.filter { it.isPinned }
                 val nonPinnedLivres = uiState.livres.filter { !it.isPinned }
-                LazyColumn {
+                LazyColumn(state = listState) {
                     items(pinnedLivres, key = { it.livreId }) { item ->
                         OnKindleCard(
                             item = item,

--- a/app/src/test/java/com/lmelp/mobile/OnKindleScrollResetTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/OnKindleScrollResetTest.kt
@@ -1,0 +1,176 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.OnKindleAvecConseilRow
+import com.lmelp.mobile.data.db.OnKindleDao
+import com.lmelp.mobile.data.repository.OnKindleRepository
+import com.lmelp.mobile.viewmodel.OnKindleViewModel
+import com.lmelp.mobile.viewmodel.TriMode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Vérifie que les clés utilisées par le LaunchedEffect de scroll reset changent
+ * effectivement quand l'utilisateur bascule entre filtres ou modes de tri.
+ *
+ * Contexte : issue #103 — après changement de filtre, la liste doit toujours
+ * repartir du début (position 0) pour que les livres épinglés soient visibles.
+ * Le LaunchedEffect dans OnKindleContent est keyed sur (afficherLus, afficherNonLus, triMode).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class OnKindleScrollResetTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun fakeRow(livreId: String, titre: String, calibreLu: Int = 0) =
+        OnKindleAvecConseilRow(
+            livreId = livreId,
+            titre = titre,
+            auteurNom = null,
+            urlBabelio = null,
+            urlCover = null,
+            calibreLu = calibreLu,
+            calibreRating = null,
+            noteMoyenne = null,
+            nbAvis = 0,
+            scoreHybride = null
+        )
+
+    @Test
+    fun `changer afficherLus modifie la cle de scroll reset dans uiState`() = runTest {
+        val dao = mock<OnKindleDao>()
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1))
+            .thenReturn(listOf(fakeRow("id1", "Livre A"), fakeRow("id2", "Livre B Lu", calibreLu = 1)))
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 0, afficherNonLus = 1))
+            .thenReturn(listOf(fakeRow("id1", "Livre A")))
+        val repo = OnKindleRepository(dao)
+        val vm = OnKindleViewModel(repo)
+        advanceUntilIdle()
+
+        val afficherLusAvant = vm.uiState.value.afficherLus
+
+        vm.setAfficherLus(false)
+        advanceUntilIdle()
+
+        val afficherLusApres = vm.uiState.value.afficherLus
+        assertNotEquals(
+            "afficherLus doit changer pour déclencher le LaunchedEffect de scroll reset",
+            afficherLusAvant, afficherLusApres
+        )
+        assertEquals(false, afficherLusApres)
+    }
+
+    @Test
+    fun `changer afficherNonLus modifie la cle de scroll reset dans uiState`() = runTest {
+        val dao = mock<OnKindleDao>()
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1))
+            .thenReturn(listOf(fakeRow("id1", "Livre A")))
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 0))
+            .thenReturn(listOf(fakeRow("id2", "Livre Lu", calibreLu = 1)))
+        val repo = OnKindleRepository(dao)
+        val vm = OnKindleViewModel(repo)
+        advanceUntilIdle()
+
+        val afficherNonLusAvant = vm.uiState.value.afficherNonLus
+
+        vm.setAfficherNonLus(false)
+        advanceUntilIdle()
+
+        val afficherNonLusApres = vm.uiState.value.afficherNonLus
+        assertNotEquals(
+            "afficherNonLus doit changer pour déclencher le LaunchedEffect de scroll reset",
+            afficherNonLusAvant, afficherNonLusApres
+        )
+        assertEquals(false, afficherNonLusApres)
+    }
+
+    @Test
+    fun `changer triMode modifie la cle de scroll reset dans uiState`() = runTest {
+        val dao = mock<OnKindleDao>()
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1))
+            .thenReturn(listOf(fakeRow("id1", "Livre A"), fakeRow("id2", "Livre B")))
+        val repo = OnKindleRepository(dao)
+        val vm = OnKindleViewModel(repo)
+        advanceUntilIdle()
+
+        val triModeAvant = vm.uiState.value.triMode
+        assertEquals(TriMode.ALPHA, triModeAvant)
+
+        vm.setTriMode(TriMode.NOTE_MASQUE)
+        advanceUntilIdle()
+
+        val triModeApres = vm.uiState.value.triMode
+        assertNotEquals(
+            "triMode doit changer pour déclencher le LaunchedEffect de scroll reset",
+            triModeAvant, triModeApres
+        )
+        assertEquals(TriMode.NOTE_MASQUE, triModeApres)
+    }
+
+    @Test
+    fun `changer de filtre apres scroll reaffiche les livres epingles depuis le debut`() = runTest {
+        // Ce test vérifie que les livres épinglés sont toujours en position 0 après
+        // un changement de filtre — ils ne doivent jamais être hors-écran au-dessus.
+        val dao = mock<OnKindleDao>()
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 1, afficherNonLus = 1))
+            .thenReturn(
+                listOf(
+                    fakeRow("pinned", "Épinglé"),
+                    fakeRow("id2", "Livre B"),
+                    fakeRow("id3", "Livre C"),
+                    fakeRow("id4", "Livre D Lu", calibreLu = 1)
+                )
+            )
+        whenever(dao.getOnKindleAvecConseil(afficherLus = 0, afficherNonLus = 1))
+            .thenReturn(
+                listOf(
+                    fakeRow("pinned", "Épinglé"),
+                    fakeRow("id2", "Livre B"),
+                    fakeRow("id3", "Livre C")
+                )
+            )
+        val prefs = FakeUserPreferencesRepository()
+        prefs.togglePinnedReading("pinned")
+        val repo = OnKindleRepository(dao)
+        val vm = OnKindleViewModel(repo, prefs)
+        advanceUntilIdle()
+
+        // Vérifier que l'épinglé est bien en position 0 initialement
+        assertEquals("pinned", vm.uiState.value.livres[0].livreId)
+        assertEquals(true, vm.uiState.value.livres[0].isPinned)
+
+        // Simuler un changement de filtre (comme si l'utilisateur avait scrollé puis changé)
+        vm.setAfficherLus(false)
+        advanceUntilIdle()
+
+        // Après changement de filtre, l'épinglé doit toujours être en position 0
+        assertEquals(
+            "Le livre épinglé doit rester en position 0 après changement de filtre",
+            "pinned", vm.uiState.value.livres[0].livreId
+        )
+        assertEquals(true, vm.uiState.value.livres[0].isPinned)
+        // Et le LaunchedEffect (keyed sur afficherLus) doit déclencher scrollToItem(0) côté UI
+        assertEquals(false, vm.uiState.value.afficherLus)
+    }
+}

--- a/docs/claude/memory/260512-1430-issue103-scroll-reset-liseuse.md
+++ b/docs/claude/memory/260512-1430-issue103-scroll-reset-liseuse.md
@@ -1,0 +1,40 @@
+# Issue #103 — Scroll reset de la liste liseuse lors du changement de filtre
+
+## Contexte
+
+Écran "Sur ma liseuse" (`OnKindleScreen`) : en alternant entre les filtres (Lus/Non lus) ou les modes de tri, la liste `LazyColumn` ne repartait pas du début. Les livres épinglés (toujours en tête) pouvaient donc rester hors-écran si l'utilisateur avait scrollé vers le bas avant de changer de filtre.
+
+## Root cause
+
+Le `LazyColumn` dans `OnKindleContent` n'avait pas de `LazyListState` explicite. Compose conserve la position de scroll entre recompositions, même quand le contenu change complètement.
+
+## Fix
+
+Dans `app/src/main/java/com/lmelp/mobile/ui/onkindle/OnKindleScreen.kt`, dans le bloc `else` de `OnKindleContent` :
+
+```kotlin
+val listState = rememberLazyListState()
+LaunchedEffect(uiState.afficherLus, uiState.afficherNonLus, uiState.triMode) {
+    listState.scrollToItem(0)
+}
+LazyColumn(state = listState) { ... }
+```
+
+- `rememberLazyListState()` donne le contrôle explicite du scroll
+- `LaunchedEffect` keyed sur les 3 filtres/tri déclenche `scrollToItem(0)` à chaque changement
+- Pattern standard Compose pour reset de scroll sur changement de contenu
+
+## Tests
+
+Fichier `app/src/test/java/com/lmelp/mobile/OnKindleScrollResetTest.kt` (4 tests JVM) :
+- Documentent que les clés du `LaunchedEffect` changent bien dans le ViewModel lors de chaque action filtre/tri
+- La partie scroll (UI pure) est couverte par test manuel
+- Test notable : vérifie que le livre épinglé reste en position 0 du ViewModel après changement de filtre
+
+## Pattern à retenir
+
+Pour tout `LazyColumn` dont le contenu change suite à des filtres/tri, ajouter systématiquement :
+- `rememberLazyListState()`
+- `LaunchedEffect(clé1, clé2, ...)` → `scrollToItem(0)`
+
+Ceci s'applique potentiellement à d'autres écrans (Palmarès, Recommandations) si le même problème apparaît.


### PR DESCRIPTION
## Summary

- Le `LazyColumn` de l'écran "Sur ma liseuse" conservait sa position de scroll lors d'un changement de filtre (Lus/Non lus) ou de mode de tri, rendant les livres épinglés en tête de liste invisibles si l'utilisateur avait scrollé vers le bas
- Ajout d'un `rememberLazyListState()` + `LaunchedEffect(afficherLus, afficherNonLus, triMode)` → `scrollToItem(0)` dans `OnKindleContent`
- 4 tests JVM ajoutés dans `OnKindleScrollResetTest` documentant le contrat ViewModel

## Test plan

- [ ] Ouvrir "Sur ma liseuse" avec des livres épinglés
- [ ] Scroller vers le bas
- [ ] Basculer entre les filtres Lus / Non lus → la liste repart du début
- [ ] Changer le mode de tri → la liste repart du début
- [ ] Les livres épinglés sont toujours visibles en tête après changement de filtre

Fixes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)