### PR TITLE
feat(livre): bouton de partage URL Babelio sur la fiche livre (#110)

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.lmelp.mobile.ui.emissions
 
+import android.content.Intent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -17,6 +18,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Share
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -36,6 +38,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -105,6 +108,7 @@ fun LivreDetailContent(
     onCritiqueClick: (String) -> Unit = {},
     modifier: Modifier = Modifier
 ) {
+    val context = LocalContext.current
     var showCoverFullscreen by remember { mutableStateOf(false) }
 
     if (showCoverFullscreen && livre.urlCover != null) {
@@ -186,8 +190,27 @@ fun LivreDetailContent(
                     }
                 }
                 Column(horizontalAlignment = Alignment.End) {
-                    livre.noteMoyenne?.let {
-                        NoteBadge(note = it, fontSize = 32.sp)
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        livre.urlBabelio?.let { url ->
+                            IconButton(
+                                onClick = {
+                                    val sendIntent = Intent(Intent.ACTION_SEND).apply {
+                                        putExtra(Intent.EXTRA_TEXT, url)
+                                        type = "text/plain"
+                                    }
+                                    context.startActivity(Intent.createChooser(sendIntent, null))
+                                }
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Default.Share,
+                                    contentDescription = "Partager",
+                                    tint = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+                        }
+                        livre.noteMoyenne?.let {
+                            NoteBadge(note = it, fontSize = 32.sp)
+                        }
                     }
                     CalibreBadge(
                         calibreInLibrary = livre.calibreInLibrary,

--- a/app/src/test/java/com/lmelp/mobile/LivreDetailShareTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/LivreDetailShareTest.kt
@@ -1,0 +1,56 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.AvisAvecEmissionRow
+import com.lmelp.mobile.data.db.LivreAvecCalibreRow
+import com.lmelp.mobile.data.db.LivresDao
+import com.lmelp.mobile.data.repository.LivresRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class LivreDetailShareTest {
+
+    private fun makeLivreAvecCalibreRow(urlBabelio: String? = null) = LivreAvecCalibreRow(
+        id = "l1",
+        titre = "Mon Livre",
+        auteurId = null,
+        auteurNom = "Auteur Test",
+        editeur = null,
+        urlBabelio = urlBabelio,
+        urlCover = null,
+        createdAt = null,
+        updatedAt = null
+    )
+
+    @Test
+    fun `urlBabelio est propagee depuis LivreAvecCalibreRow vers LivreDetailUi`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibreRow(urlBabelio = "https://www.babelio.com/livres/Test/123456")
+        )
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList<AvisAvecEmissionRow>())
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")
+
+        assertEquals("https://www.babelio.com/livres/Test/123456", result!!.urlBabelio)
+    }
+
+    @Test
+    fun `urlBabelio est null dans LivreDetailUi quand le livre na pas d url babelio`() = runTest {
+        val dao = mock<LivresDao>()
+        whenever(dao.getLivreAvecCalibreById(any())).thenReturn(
+            makeLivreAvecCalibreRow(urlBabelio = null)
+        )
+        whenever(dao.getAvisAvecEmissionByLivre(any())).thenReturn(emptyList<AvisAvecEmissionRow>())
+
+        val repo = LivresRepository(dao)
+        val result = repo.getLivreDetail("l1")
+
+        assertNull(result!!.urlBabelio)
+    }
+}

--- a/docs/claude/memory/260522-1910-issue110-partage-livre.md
+++ b/docs/claude/memory/260522-1910-issue110-partage-livre.md
@@ -1,0 +1,73 @@
+# Issue #110 — Partage livre (bouton share sur fiche livre)
+
+## Résumé
+
+Ajout d'un bouton de partage sur la page de détail d'un livre, permettant de partager l'URL Babelio via le menu Android natif (SMS, WhatsApp, email...).
+
+## Fichiers modifiés
+
+- `app/src/main/java/com/lmelp/mobile/ui/emissions/LivreDetailScreen.kt` — ajout du bouton partage
+- `app/src/test/java/com/lmelp/mobile/LivreDetailShareTest.kt` — tests unitaires (nouveau fichier)
+
+## Implémentation
+
+### Layout final
+
+Dans `LivreDetailContent()`, la colonne de droite du bandeau header contient une `Row` qui regroupe l'icône de partage et le `NoteBadge` côte à côte (centrés verticalement), avec `CalibreBadge` en dessous :
+
+```
+Column(horizontalAlignment = End)
+  ├── Row(verticalAlignment = CenterVertically)
+  │     ├── IconButton(Share)   ← visible si urlBabelio != null
+  │     └── NoteBadge(note)     ← visible si noteMoyenne != null
+  └── CalibreBadge
+```
+
+### Intent de partage
+
+```kotlin
+val sendIntent = Intent(Intent.ACTION_SEND).apply {
+    putExtra(Intent.EXTRA_TEXT, url)
+    type = "text/plain"
+}
+context.startActivity(Intent.createChooser(sendIntent, null))
+```
+
+`context` obtenu via `LocalContext.current` en haut de `LivreDetailContent()`.
+
+### Couleur de l'icône
+
+Utiliser `tint = MaterialTheme.colorScheme.onSurface` (noir/blanc selon thème).
+**Ne pas utiliser** `colorScheme.primary` qui est rouge dans ce thème.
+
+### Données
+
+`urlBabelio` était déjà présent dans `LivreAvecCalibreRow` et `LivreDetailUi` — aucun changement data layer nécessaire.
+
+## Tests
+
+`app/src/test/java/com/lmelp/mobile/LivreDetailShareTest.kt` — 2 tests unitaires :
+- `urlBabelio` propagée correctement depuis `LivreAvecCalibreRow` vers `LivreDetailUi`
+- `urlBabelio` null quand absent
+
+## Leçons apprises
+
+### Gradle cache bloquant la recompilation
+
+Symptôme : `build.sh` affiche "38 actionable tasks: 38 up-to-date" alors que des fichiers sources ont changé.
+Solution : forcer avec `--rerun-tasks` sur la tâche de compilation :
+```bash
+./gradlew :app:compileDebugKotlin --rerun-tasks
+./gradlew assembleDebug
+```
+
+### ADB vide après mise à jour Android
+
+Symptôme : `adb devices` vide, téléphone visible dans `lsusb` avec `18d1:4ee1`.
+Mauvaise piste : règle udev (inutile dans ce cas).
+Solution réelle : **rebooter le téléphone** — la mise à jour Android l'avait laissé dans un état USB intermédiaire.
+Leçon : toujours essayer le reboot du téléphone en premier avant de chercher des causes système complexes.
+
+### Préférences USB Android réinitialisées après OTA
+
+Une mise à jour Android peut remettre les préférences USB à "Aucun transfert de données". Si "Appareil connecté" échoue avec "Échec du changement", c'est un symptôme d'état intermédiaire post-OTA — le reboot résout.

--- a/docs/dev/build_deploy_apk.md
+++ b/docs/dev/build_deploy_apk.md
@@ -64,6 +64,8 @@ Si le device ne s'affiche pas :
 - un `adb kill-server` peut aider, revoquer les autorisations de debogage USB, et relancer `adb devices` (une popup d'autorisation doit arriver)
 - il faut aussi que le debogage USB soit active
 
+Parfois un reboot du téléphone peut aider.
+
 
 ```bash
 # liste les telephones connectes en USB

--- a/docs/user/partager_livre.md
+++ b/docs/user/partager_livre.md
@@ -1,0 +1,13 @@
+# Partager un livre
+
+Sur la **fiche détail d'un livre**, un bouton de partage permet d'envoyer l'URL Babelio du livre via n'importe quelle application installée sur le téléphone (SMS, WhatsApp, email, etc.).
+
+## Comment partager
+
+1. Ouvrir la fiche d'un livre (depuis le Palmarès, les Émissions, la Recherche, etc.)
+2. Appuyer sur l'icône de partage (trois cercles connectés) en haut à droite, à côté de la note
+3. Choisir l'application de partage dans le menu Android
+
+Le lien partagé pointe vers la page Babelio du livre — le destinataire peut l'ouvrir directement dans son navigateur.
+
+> Le bouton n'apparaît que si le livre possède une URL Babelio dans la base de données.


### PR DESCRIPTION
## Résumé

- Ajout d'un bouton de partage (icône Android standard 3 cercles) sur la fiche détail d'un livre
- Positionné à côté de la note moyenne, dans le bandeau header en haut à droite
- Au clic : ouvre le menu de partage Android natif avec l'URL Babelio du livre
- Le bouton n'est affiché que si `urlBabelio` est non-null

## Test plan

- [ ] Ouvrir la fiche d'un livre possédant une URL Babelio → l'icône de partage apparaît à gauche de la note
- [ ] Cliquer sur l'icône → le menu de partage Android s'ouvre avec l'URL Babelio
- [ ] Vérifier qu'un livre sans URL Babelio n'affiche pas le bouton
- [ ] Tests unitaires : `./gradlew :app:testDebugUnitTest`

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)