### PR TITLE
feat(conseils): afficher le badge Calibre sur les livres recommandés

### DIFF
--- a/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt
@@ -114,7 +114,10 @@ data class RecommendationUi(
     val auteurNom: String?,
     val scoreHybride: Double,
     val masqueMean: Double?,
-    val urlCover: String? = null
+    val urlCover: String? = null,
+    val calibreInLibrary: Boolean = false,
+    val calibreLu: Boolean = false,
+    val calibreRating: Double? = null
 )
 
 data class SearchResultUi(

--- a/app/src/main/java/com/lmelp/mobile/data/repository/RecommendationsRepository.kt
+++ b/app/src/main/java/com/lmelp/mobile/data/repository/RecommendationsRepository.kt
@@ -16,7 +16,10 @@ class RecommendationsRepository(
                 auteurNom = it.auteurNom,
                 scoreHybride = it.scoreHybride,
                 masqueMean = it.masqueMean,
-                urlCover = it.urlCover
+                urlCover = it.urlCover,
+                calibreInLibrary = it.calibreInLibrary == 1,
+                calibreLu = it.calibreLu == 1,
+                calibreRating = null
             )
         }
     }

--- a/app/src/main/java/com/lmelp/mobile/ui/recommendations/RecommendationsScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/recommendations/RecommendationsScreen.kt
@@ -28,6 +28,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import com.lmelp.mobile.data.model.RecommendationUi
 import com.lmelp.mobile.data.repository.RecommendationsRepository
 import com.lmelp.mobile.ui.components.BookCoverThumbnail
+import com.lmelp.mobile.ui.components.CalibreBadge
 import com.lmelp.mobile.ui.components.EmptyState
 import com.lmelp.mobile.ui.components.ErrorMessage
 import com.lmelp.mobile.ui.components.LoadingIndicator
@@ -105,6 +106,11 @@ fun RecommendationCard(item: RecommendationUi, displayRank: Int, onClick: () -> 
                 Text(text = item.titre, style = MaterialTheme.typography.titleSmall)
                 item.auteurNom?.let { Text(it, style = MaterialTheme.typography.bodySmall) }
             }
+            CalibreBadge(
+                calibreInLibrary = item.calibreInLibrary,
+                calibreLu = item.calibreLu,
+                calibreRating = item.calibreRating
+            )
             item.masqueMean?.let { NoteBadge(note = it) }
         }
     }

--- a/app/src/test/java/com/lmelp/mobile/RecommendationsCalibreBadgeTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/RecommendationsCalibreBadgeTest.kt
@@ -1,0 +1,77 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.db.RecommandationNonLueAvecUrlRow
+import com.lmelp.mobile.data.db.RecommendationsDao
+import com.lmelp.mobile.data.repository.RecommendationsRepository
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+/**
+ * Tests TDD pour la propagation des champs Calibre (calibre_in_library, calibre_lu, calibre_rating)
+ * dans RecommendationsRepository, pour l'affichage du badge Calibre sur la page Conseils (issue #113).
+ */
+class RecommendationsCalibreBadgeTest {
+
+    private fun makeRow(
+        livreId: String,
+        calibreInLibrary: Int = 0,
+        calibreLu: Int = 0
+    ) = RecommandationNonLueAvecUrlRow(
+        rank = 1,
+        livreId = livreId,
+        titre = "Titre $livreId",
+        auteurNom = "Auteur",
+        scoreHybride = 0.9,
+        masqueMean = null,
+        calibreInLibrary = calibreInLibrary,
+        calibreLu = calibreLu,
+        urlCover = null
+    )
+
+    @Test
+    fun `RecommendationUi calibreInLibrary true et calibreLu false quand livre present non lu`() = runTest {
+        val dao = mock<RecommendationsDao>()
+        whenever(dao.getRecommandationsNonLuesAvecUrl()).thenReturn(
+            listOf(makeRow("l1", calibreInLibrary = 1, calibreLu = 0))
+        )
+
+        val repo = RecommendationsRepository(dao)
+        val result = repo.getAllRecommendations()
+
+        assertTrue(result[0].calibreInLibrary)
+        assertFalse(result[0].calibreLu)
+    }
+
+    @Test
+    fun `RecommendationUi calibre fields false quand livre absent de Calibre`() = runTest {
+        val dao = mock<RecommendationsDao>()
+        whenever(dao.getRecommandationsNonLuesAvecUrl()).thenReturn(
+            listOf(makeRow("l1", calibreInLibrary = 0, calibreLu = 0))
+        )
+
+        val repo = RecommendationsRepository(dao)
+        val result = repo.getAllRecommendations()
+
+        assertFalse(result[0].calibreInLibrary)
+        assertFalse(result[0].calibreLu)
+    }
+
+    @Test
+    fun `RecommendationUi calibreRating est toujours null`() = runTest {
+        val dao = mock<RecommendationsDao>()
+        whenever(dao.getRecommandationsNonLuesAvecUrl()).thenReturn(
+            listOf(makeRow("l1", calibreInLibrary = 1, calibreLu = 0))
+        )
+
+        val repo = RecommendationsRepository(dao)
+        val result = repo.getAllRecommendations()
+
+        assertNull(result[0].calibreRating)
+    }
+}

--- a/docs/claude/memory/260816-2015-issue113-conseils-badge-calibre.md
+++ b/docs/claude/memory/260816-2015-issue113-conseils-badge-calibre.md
@@ -1,0 +1,30 @@
+# Issue #113 — Badge Calibre sur la page Conseils (Recommandations)
+
+## Contexte
+
+La page Palmarès affichait déjà un petit rond (`✓` vert si lu, `◯` gris si présent mais non lu) pour indiquer qu'un livre est dans la bibliothèque Calibre. La page Conseils (recommandations) n'affichait rien de tel. L'utilisateur a demandé d'ajouter ce même indicateur sur Conseils.
+
+## Découverte clé : composable déjà réutilisable, non utilisé partout
+
+Un composable partagé `CalibreBadge` existait déjà dans `app/src/main/java/com/lmelp/mobile/ui/components/CommonComponents.kt:92-116`, utilisé par `EmissionDetailScreen`, `AuteurDetailScreen` et `LivreDetailScreen` (introduit lors de l'issue #84, voir `260409-1642-issue84-calibre-badge-fiche-auteur-emission.md`). Mais `PalmaresScreen.kt` ne l'utilisait pas : son `PalmaresCard` dupliquait le même rendu inline (lignes 207-224). Pour Conseils, on a réutilisé `CalibreBadge` directement plutôt que de dupliquer à nouveau le code — le refactor de `PalmaresCard` pour utiliser aussi `CalibreBadge` a été jugé hors scope de cette issue et laissé de côté.
+
+## Contrainte découverte : la query SQL de Conseils filtre déjà les livres lus
+
+`RecommendationsDao.getRecommandationsNonLuesAvecUrl()` (`app/src/main/java/com/lmelp/mobile/data/db/RecommendationsDao.kt:77-89`) exclut déjà les livres avec `calibre_in_library=1 ET calibre_lu=1`. Conséquence : un livre affiché dans Conseils ne peut être que "absent de Calibre" ou "présent mais non lu" — jamais "lu". Donc dans cet écran, le badge ne peut afficher que le rond gris `◯`, jamais le `✓` vert avec la note personnelle.
+
+Décision validée avec l'utilisateur : ne pas ajouter `calibre_rating` à la requête SQL (il serait toujours `null` en pratique vu le filtre existant) — on passe `calibreRating = null` en dur depuis le repository. Pas de changement du DAO nécessaire : les colonnes `calibre_in_library`/`calibre_lu` étaient déjà exposées dans `RecommandationNonLueAvecUrlRow` mais simplement non mappées jusqu'ici vers `RecommendationUi`.
+
+## Modifications
+
+- `app/src/main/java/com/lmelp/mobile/data/model/UiModels.kt` — `RecommendationUi` : ajout de `calibreInLibrary: Boolean = false`, `calibreLu: Boolean = false`, `calibreRating: Double? = null` (même pattern que `LivreUi`, `PalmaresUi`, `LivreParAuteurUi`).
+- `app/src/main/java/com/lmelp/mobile/data/repository/RecommendationsRepository.kt` — `getAllRecommendations()` mappe désormais `calibreInLibrary = it.calibreInLibrary == 1`, `calibreLu = it.calibreLu == 1`, `calibreRating = null`.
+- `app/src/main/java/com/lmelp/mobile/ui/recommendations/RecommendationsScreen.kt` — `RecommendationCard` appelle `CalibreBadge(...)` entre la colonne titre/auteur et le `NoteBadge` final, import ajouté (`com.lmelp.mobile.ui.components.CalibreBadge`).
+- Nouveau fichier de test `app/src/test/java/com/lmelp/mobile/RecommendationsCalibreBadgeTest.kt`, calqué sur `CalibreBadgeRepositoryTest.kt` de l'issue #84 : mock du DAO avec `mockito-kotlin`, vérifie le mapping Int→Boolean et que `calibreRating` reste `null`.
+
+## TDD
+
+RED confirmé par erreur de compilation (`Unresolved reference 'calibreInLibrary'` etc.) avant modification de `RecommendationUi`. GREEN après les 3 modifications ci-dessus — `./gradlew :app:testDebugUnitTest` et `./gradlew lint` passent sans erreur. APK debug buildé (`./gradlew assembleDebug`) et testé manuellement par l'utilisateur avec succès ("j'ai deployé et ça marche parfaitement").
+
+## À retenir pour les prochaines features Calibre
+
+Avant d'ajouter le badge Calibre sur un nouvel écran, vérifier si le DAO/query expose déjà `calibre_in_library`/`calibre_lu`/`calibre_rating` — souvent déjà présent dans les jointures existantes mais pas encore mappé côté UI model, comme c'était le cas ici. Toujours réutiliser `CalibreBadge` (`ui/components/CommonComponents.kt`) plutôt que dupliquer son rendu.


### PR DESCRIPTION
## Summary
- Ajoute le badge Calibre (`✓` vert si lu, `◯` gris si présent non lu) sur la page Conseils, en réutilisant le composable partagé `CalibreBadge` déjà utilisé par les fiches Émission/Auteur/Livre
- `RecommendationUi` expose désormais `calibreInLibrary`/`calibreLu`/`calibreRating`, mappés depuis les colonnes déjà présentes dans `RecommandationNonLueAvecUrlRow` (aucun changement de la requête SQL)

## Test plan
- [x] Tests unitaires RED confirmés avant modification (`RecommendationsCalibreBadgeTest.kt` échoue à la compilation)
- [x] Tests unitaires GREEN après implémentation (`./gradlew :app:testDebugUnitTest`)
- [x] `./gradlew lint` sans erreur
- [x] `mkdocs build --strict` sans erreur
- [x] CI/CD (Continuous Integration + Deploy Documentation) verte sur la branche
- [x] Test manuel sur device confirmé par l'utilisateur ("déployé, ça marche parfaitement")

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)