### PR TITLE
ADR: séparer mise à jour appli / mise à jour données

### DIFF
--- a/.github/workflows/publish-data-release.yml
+++ b/.github/workflows/publish-data-release.yml
@@ -1,0 +1,76 @@
+name: Publish Data Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      db_path:
+        description: "Chemin d'un lmelp.db déjà généré à publier (laisser vide pour regénérer depuis MONGO_URI)"
+        required: false
+        default: ""
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Python dependencies
+        run: pip install pymongo numpy scipy click
+
+      - name: Export MongoDB to SQLite
+        if: ${{ inputs.db_path == '' }}
+        env:
+          MONGO_URI: ${{ secrets.MONGO_URI }}
+        run: |
+          python scripts/export_mongo_to_sqlite.py \
+            --mongo-uri "$MONGO_URI" \
+            --output /tmp/lmelp.db \
+            --force
+
+      - name: Resolve db path
+        id: db
+        run: |
+          if [ -n "${{ inputs.db_path }}" ]; then
+            echo "path=${{ inputs.db_path }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "path=/tmp/lmelp.db" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify SQLite database
+        run: |
+          python scripts/export_mongo_to_sqlite.py --verify "${{ steps.db.outputs.path }}"
+
+      - name: Stage release asset as lmelp.db
+        run: cp "${{ steps.db.outputs.path }}" /tmp/lmelp-release.db
+
+      - name: Generate metadata.json
+        run: |
+          python scripts/generate_data_release_metadata.py \
+            --db /tmp/lmelp-release.db \
+            --output /tmp/metadata.json
+
+      - name: Rename release asset to lmelp.db
+        run: mv /tmp/lmelp-release.db /tmp/lmelp.db
+
+      - name: Publish data release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: data-latest
+          name: "lmelp-mobile — données"
+          body: |
+            ## Base de données lmelp
+
+            Publiée automatiquement (workflow `publish-data-release.yml`).
+            Voir `metadata.json` pour la date d'export, le nombre d'émissions/livres/avis et le SHA-256.
+          files: |
+            /tmp/lmelp.db
+            /tmp/metadata.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,7 +156,13 @@ Le container `lmelp-export` tourne en daemon avec la stack `docker-lmelp`. Il :
 
 Le service `lmelp-export` est défini dans le `docker-compose.yml` du repo `castorfou/docker-lmelp`.
 
-⚠️ **`user_version` = timestamp Unix** : le script d'export écrit `PRAGMA user_version = <timestamp>` à chaque génération. Room utilise cette valeur pour détecter si la DB dans les assets est plus récente que celle sur le téléphone — même lors d'un push ADB direct. Si le container pousse une DB avec un `user_version` identique à celui déjà en place, Room peut ignorer la mise à jour et conserver l'ancienne en cache (voir issue #102).
+⚠️ **`PRAGMA user_version` ≠ timestamp** : `PRAGMA user_version` est un entier **fixe** égal au numéro de schéma Room (`ROOM_VERSION` dans le script d'export, synchronisé avec `version = N` dans `LmelpDatabase.kt`) — il ne change qu'en cas de migration de schéma, pas à chaque export. Le **timestamp Unix de l'export** est stocké séparément dans la table `db_metadata` (clé `version`), avec `export_date`/`export_datetime`. Room utilise `PRAGMA user_version` pour détecter une incompatibilité de schéma (déclenchant `fallbackToDestructiveMigration()`), pas pour détecter une DB « plus récente » au sens fraîcheur des données — c'est `db_metadata.export_date`/`version` qu'il faut comparer pour ça (voir issue #102, et l'ADR [0001](docs/dev/adr/0001-separation-maj-appli-donnees.md) pour le futur mécanisme de détection de mise à jour côté app).
+
+### Mise à jour DB sans ADB (cible, issue #116)
+
+Le mécanisme ADB ci-dessus (USB + laptop + build debug) devient impraticable avec la migration de `docker-lmelp` vers un NAS ([docker-lmelp#47](https://github.com/castorfou/docker-lmelp/issues/47)) — plus de laptop branché en USB en usage courant. La cible retenue : publier `lmelp.db` comme asset d'une **GitHub Release dédiée** (`data-latest`), téléchargeable en HTTP par l'app elle-même, sans dépendance ADB/USB/build debug.
+
+Voir l'ADR complet : [docs/dev/adr/0001-separation-maj-appli-donnees.md](docs/dev/adr/0001-separation-maj-appli-donnees.md). Le mécanisme ADB ci-dessus reste documenté et fonctionnel comme solution **legacy/dev-only** tant que l'implémentation Kotlin du téléchargement (issue de suivi [#118](https://github.com/castorfou/lmelp-mobile/issues/118)) n'est pas livrée.
 
 ## Architecture MVVM
 

--- a/Dockerfile.export
+++ b/Dockerfile.export
@@ -1,10 +1,21 @@
 FROM python:3.11-slim
 
-# Install ADB and system dependencies
+# Install ADB, anacron, gh CLI and system dependencies.
+# anacron : publication automatique de la Release data-latest (issue #116),
+# suit le même pattern que mongodb.Dockerfile (repo docker-lmelp) — robuste
+# aux coupures/redémarrages du NAS, contrairement à un cron classique.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     android-tools-adb \
+    anacron \
+    curl \
     gcc \
+    gpg \
     python3-dev \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+        -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+        > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
@@ -15,12 +26,42 @@ COPY pyproject.toml README.md ./
 # Stub src/ pour que pip install -e . réussisse sans le code source complet
 RUN mkdir -p src && pip install --no-cache-dir -e .
 
-# Copy export script
+# Copy export scripts
 COPY scripts/export_mongo_to_sqlite.py scripts/
+COPY scripts/generate_data_release_metadata.py scripts/
 
-# Entrypoint script
+# Entrypoint scripts
 COPY scripts/docker_export_and_push.sh /usr/local/bin/export-and-push
 RUN chmod +x /usr/local/bin/export-and-push
+COPY scripts/docker_export_and_publish_release.sh /usr/local/bin/export-and-publish-release
+RUN chmod +x /usr/local/bin/export-and-publish-release
 
-# En mode daemon : le container reste actif, on appelle export-and-push via docker exec
+# ---------------------------------------------------------------------------
+# anacron : publication quotidienne automatique de data-latest (non bloquant
+# si GH_TOKEN absent — export-and-publish-release échoue proprement dans ce
+# cas, voir docker-lmelp#56 pour le provisioning du secret).
+# ---------------------------------------------------------------------------
+RUN mkdir -p /etc/anacron.daily && \
+    echo '#!/bin/bash' > /etc/anacron.daily/publish-data-release && \
+    echo 'export-and-publish-release >> /var/log/publish-data-release.log 2>&1' \
+        >> /etc/anacron.daily/publish-data-release && \
+    chmod +x /etc/anacron.daily/publish-data-release && \
+    echo '1 10 publish-data-release /etc/anacron.daily/publish-data-release' \
+        >> /etc/anacrontab
+
+# Entrypoint custom : lance la boucle anacron en arrière-plan, puis garde le
+# container actif (pas de process principal de longue durée à exec ici,
+# contrairement à mongodb.Dockerfile).
+RUN echo '#!/bin/bash' > /docker-entrypoint-anacron.sh && \
+    echo 'set -e' >> /docker-entrypoint-anacron.sh && \
+    echo 'mkdir -p /var/spool/anacron /var/log' >> /docker-entrypoint-anacron.sh && \
+    echo '(while true; do anacron -d; sleep "${ANACRON_LOOP_INTERVAL:-3600}"; done) &' \
+        >> /docker-entrypoint-anacron.sh && \
+    echo 'exec "$@"' >> /docker-entrypoint-anacron.sh && \
+    chmod +x /docker-entrypoint-anacron.sh
+
+ENTRYPOINT ["/docker-entrypoint-anacron.sh"]
+
+# En mode daemon : le container reste actif, on appelle export-and-push /
+# export-and-publish-release via docker exec (en plus du job anacron ci-dessus)
 CMD ["sleep", "infinity"]

--- a/app/src/main/java/com/lmelp/mobile/Navigation.kt
+++ b/app/src/main/java/com/lmelp/mobile/Navigation.kt
@@ -67,7 +67,7 @@ fun LmelpNavHost(
         }
 
         composable(Routes.ABOUT) {
-            AboutScreen()
+            AboutScreen(repository = app.metadataRepository)
         }
 
         composable(

--- a/app/src/main/java/com/lmelp/mobile/ui/about/AboutScreen.kt
+++ b/app/src/main/java/com/lmelp/mobile/ui/about/AboutScreen.kt
@@ -12,13 +12,24 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.lmelp.mobile.BuildConfig
+import com.lmelp.mobile.data.model.DbInfoUi
+import com.lmelp.mobile.data.repository.MetadataRepository
+import com.lmelp.mobile.viewmodel.AboutViewModel
 
 data class ChangelogEntry(val hash: String, val message: String, val date: String)
+
+/** Résumé lisible des infos DB pour AboutScreen (issue #116). */
+fun formatDbInfoSummary(dbInfo: DbInfoUi): String =
+    "Export du ${dbInfo.exportDate} — " +
+        "${dbInfo.nbEmissions} émissions, ${dbInfo.nbLivres} livres, ${dbInfo.nbAvis} avis"
 
 fun parseChangelog(raw: String): List<ChangelogEntry> {
     if (raw.isBlank()) return emptyList()
@@ -32,11 +43,14 @@ fun parseChangelog(raw: String): List<ChangelogEntry> {
 }
 
 @Composable
-fun AboutScreen(modifier: Modifier = Modifier) {
+fun AboutScreen(repository: MetadataRepository, modifier: Modifier = Modifier) {
+    val viewModel: AboutViewModel = viewModel(factory = AboutViewModel.Factory(repository))
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     AboutContent(
         gitCommit = BuildConfig.GIT_COMMIT,
         buildDate = BuildConfig.BUILD_DATE,
         changelog = BuildConfig.CHANGELOG,
+        dbInfo = uiState.dbInfo,
         modifier = modifier
     )
 }
@@ -46,6 +60,7 @@ fun AboutContent(
     gitCommit: String,
     buildDate: String,
     changelog: String,
+    dbInfo: DbInfoUi? = null,
     modifier: Modifier = Modifier
 ) {
     val entries = remember(changelog) { parseChangelog(changelog) }
@@ -72,6 +87,23 @@ fun AboutContent(
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
+            }
+        }
+
+        if (dbInfo != null) {
+            item {
+                Text(
+                    text = "Données",
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(bottom = 8.dp)
+                )
+                Text(
+                    text = formatDbInfoSummary(dbInfo),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(bottom = 16.dp)
+                )
+                HorizontalDivider(modifier = Modifier.padding(bottom = 16.dp))
             }
         }
 

--- a/app/src/main/java/com/lmelp/mobile/viewmodel/AboutViewModel.kt
+++ b/app/src/main/java/com/lmelp/mobile/viewmodel/AboutViewModel.kt
@@ -1,0 +1,49 @@
+package com.lmelp.mobile.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.lmelp.mobile.data.model.DbInfoUi
+import com.lmelp.mobile.data.repository.MetadataRepository
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class AboutUiState(
+    val isLoading: Boolean = false,
+    val dbInfo: DbInfoUi? = null,
+    val error: String? = null
+)
+
+class AboutViewModel(private val repository: MetadataRepository) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AboutUiState())
+    val uiState: StateFlow<AboutUiState> = _uiState.asStateFlow()
+
+    init {
+        loadDbInfo()
+    }
+
+    private fun loadDbInfo() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true) }
+            try {
+                val dbInfo = repository.getDbInfo()
+                _uiState.update { it.copy(isLoading = false, dbInfo = dbInfo) }
+            } catch (e: Exception) {
+                if (e is CancellationException) throw e
+                _uiState.update { it.copy(isLoading = false, error = e.message) }
+            }
+        }
+    }
+
+    class Factory(private val repository: MetadataRepository) : ViewModelProvider.Factory {
+        override fun <T : ViewModel> create(modelClass: Class<T>): T {
+            @Suppress("UNCHECKED_CAST")
+            return AboutViewModel(repository) as T
+        }
+    }
+}

--- a/app/src/test/java/com/lmelp/mobile/DbInfoFormatterTest.kt
+++ b/app/src/test/java/com/lmelp/mobile/DbInfoFormatterTest.kt
@@ -1,0 +1,51 @@
+package com.lmelp.mobile
+
+import com.lmelp.mobile.data.model.DbInfoUi
+import com.lmelp.mobile.ui.about.formatDbInfoSummary
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Tests unitaires pour le formatage des informations de la base de données
+ * affichées dans AboutScreen (issue #116 : visibilité de la version des
+ * données en local, en préparation du futur téléchargement HTTP).
+ */
+class DbInfoFormatterTest {
+
+    private fun fakeDbInfo(
+        exportDate: String = "2026-08-19",
+        nbEmissions: String = "179",
+        nbLivres: String = "1679",
+        nbAvis: String = "4251"
+    ) = DbInfoUi(
+        exportDate = exportDate,
+        version = "1786912562",
+        nbEmissions = nbEmissions,
+        nbLivres = nbLivres,
+        nbAvis = nbAvis
+    )
+
+    @Test
+    fun `resume contient la date d export`() {
+        val summary = formatDbInfoSummary(fakeDbInfo(exportDate = "2026-08-19"))
+        assertEquals(true, summary.contains("2026-08-19"))
+    }
+
+    @Test
+    fun `resume contient le nombre d emissions`() {
+        val summary = formatDbInfoSummary(fakeDbInfo(nbEmissions = "179"))
+        assertEquals(true, summary.contains("179"))
+    }
+
+    @Test
+    fun `resume contient le nombre de livres`() {
+        val summary = formatDbInfoSummary(fakeDbInfo(nbLivres = "1679"))
+        assertEquals(true, summary.contains("1679"))
+    }
+
+    @Test
+    fun `resume contient le nombre d avis`() {
+        val summary = formatDbInfoSummary(fakeDbInfo(nbAvis = "4251"))
+        assertEquals(true, summary.contains("4251"))
+    }
+}

--- a/docs/claude/memory/260819-1430-issue116-adr-separation-maj-appli-donnees.md
+++ b/docs/claude/memory/260819-1430-issue116-adr-separation-maj-appli-donnees.md
@@ -1,0 +1,54 @@
+# Issue #116 — ADR séparation MAJ appli / MAJ données
+
+## Contexte du problème
+
+Le processus actuel de mise à jour d'un épisode mélangeait deux préoccupations derrière une seule commande ADB (`lmelp-update-mobile` → `docker exec lmelp-export export-and-push`) : la mise à jour de l'**application** (rare) et la mise à jour des **données** (fréquente, ~1x/semaine). ADB n'est en réalité nécessaire que pour le premier cas. La migration de `docker-lmelp` vers un NAS Synology (`castorfou/docker-lmelp#47`) rend le mécanisme ADB actuel (USB + laptop + build debug via `run-as`) impraticable pour la mise à jour des données au quotidien.
+
+Cette issue est une issue de **cadrage/architecture** : elle produit un ADR + un squelette CI minimal + un petit ajout UI, PAS l'implémentation Kotlin complète du téléchargement (réservée à une issue de suivi).
+
+## Décisions d'architecture retenues
+
+- **Hébergement des données** : GitHub Release asset dédié, tag `data-latest`, réutilise `softprops/action-gh-release@v2` déjà utilisé dans `release.yml` pour l'APK.
+- **C'est une étape 1 pragmatique**, pas une décision finale : l'utilisateur a un plan long terme (non démarré) de projet public multi-utilisateurs (admin qui met à jour la base commune, mode anonyme web+mobile, mode utilisateur basé sur Calibre pour recommandations personnalisées) qui remplacera ce mécanisme par un vrai backend plus tard.
+- **Publication automatique** : anacron embarqué dans `Dockerfile.export`, reproduisant exactement le pattern déjà en place et validé dans `mongodb.Dockerfile` du repo `docker-lmelp` (service `mongo`, utilisé pour rotation de logs + backup MongoDB). Anacron plutôt que cron classique car robuste aux coupures/redémarrages du NAS.
+- **Déclencheur côté app** (conception seulement, pas implémenté) : vérification au lancement de l'app (non bloquant) + bouton manuel. Pas de WorkManager/service en arrière-plan — reste fidèle à la nature offline-first de l'app.
+- **Réseau strictement optionnel/best-effort** : jamais requis pour l'usage normal.
+- **Flux APK** (mise à jour de l'application elle-même) : traité comme périphérique, piste retenue = Google Play Store, mais hors scope technique ici (implique compte développeur, review, question de droits sur le contenu Le Masque et la Plume/France Inter) → issue de suivi séparée.
+
+## Découverte technique importante : confusion `user_version` vs timestamp
+
+`scripts/export_mongo_to_sqlite.py` écrit `PRAGMA user_version = ROOM_VERSION` (entier **fixe** = numéro de schéma Room, actuellement 7, synchronisé avec `version = N` dans `app/src/main/java/com/lmelp/mobile/data/db/LmelpDatabase.kt`) — ce n'est **pas** un timestamp. Le timestamp Unix de l'export est stocké séparément dans la table `db_metadata` (clé `version`), avec `export_date`/`export_datetime`. `CLAUDE.md` contenait une confusion à ce sujet (ligne ~159, affirmait à tort que `user_version` = timestamp), corrigée dans cette issue. Room utilise `PRAGMA user_version` pour détecter une incompatibilité de **schéma** (déclenchant `fallbackToDestructiveMigration()`), pas pour détecter une DB « plus récente » en fraîcheur de données — c'est `db_metadata.export_date`/`version` qu'il faut comparer pour ça. Point important pour la future implémentation du téléchargement côté app (issue #118).
+
+## Fichiers livrés dans cette issue
+
+- `docs/dev/adr/0001-separation-maj-appli-donnees.md` + `docs/dev/adr/README.md` — premier ADR du repo, nouvelle convention à poursuivre pour les futures décisions d'architecture significatives.
+- `scripts/generate_data_release_metadata.py` (+ `tests/test_generate_data_release_metadata.py`, TDD RED→GREEN, 6 tests) — génère `metadata.json` (export_date, SHA-256, taille, compteurs) à partir de `lmelp.db`, pour permettre une future vérification de MAJ côté app sans télécharger tout le fichier (~4.4 Mo actuellement).
+- `.github/workflows/publish-data-release.yml` — workflow `workflow_dispatch` (pas de déclenchement sur tag), régénère optionnellement `lmelp.db` depuis `MONGO_URI`, génère les métadonnées, publie sur la release `data-latest`.
+- `scripts/docker_export_and_publish_release.sh` — nouvelle commande `export-and-publish-release` pour le container `lmelp-export`, publie via `gh release upload`. Nécessite `GH_TOKEN` (scope `contents:write`).
+- `Dockerfile.export` — ajout d'`anacron` + `gh` CLI (installé via le repo APT officiel GitHub CLI), job quotidien `/etc/anacron.daily/publish-data-release`, entrypoint custom `/docker-entrypoint-anacron.sh` qui lance la boucle anacron en arrière-plan avant `CMD ["sleep", "infinity"]`.
+- `app/src/main/java/com/lmelp/mobile/ui/about/AboutScreen.kt` + nouveau `app/src/main/java/com/lmelp/mobile/viewmodel/AboutViewModel.kt` — l'écran À propos affiche désormais une section "Données" (date d'export, nb émissions/livres/avis) via `MetadataRepository.getDbInfo()`, qui existait déjà mais n'était jusqu'ici jamais branché à aucune UI (seul `AccueilCarScreen.kt`, l'écran Android Auto, l'utilisait partiellement). `app/src/main/java/com/lmelp/mobile/Navigation.kt` mis à jour pour passer `app.metadataRepository` à `AboutScreen`.
+- Test `app/src/test/java/com/lmelp/mobile/DbInfoFormatterTest.kt` (TDD RED→GREEN) — teste la fonction pure `formatDbInfoSummary()` extraite dans `AboutScreen.kt`, suivant le pattern déjà établi par `parseChangelog()`/`ChangelogParserTest.kt` (pas de `createComposeRule` dans ce repo, tests Compose = logique pure extraite et testée en JVM).
+- `docs/dev/.nav.yml` — ajout de la section ADR dans la nav mkdocs (fichier `.nav.yml` géré par le plugin `awesome-nav`, pas de nav statique centralisée dans `mkdocs.yml`).
+- `CLAUDE.md`, `docs/dev/build_deploy_apk.md`, `docs/user/mise_a_jour_episode.md` — mis à jour avec des renvois vers l'ADR et le nouveau mécanisme cible.
+
+## Issues de suivi créées
+
+1. `lmelp-mobile#118` — implémentation Kotlin du téléchargement/vérification de `lmelp.db` côté app (remplacement du fichier Room avec gestion WAL, cf. bug connu issue #101).
+2. `lmelp-mobile#119` — faisabilité distribution APK (Google Play Store) et/ou ADB sans fil en dev/debug.
+3. `back-office-lmelp#262` — visibilité côté serveur des versions app/DB déployées.
+4. `docker-lmelp#56` — provisioning du secret `GH_TOKEN` + validation de l'anacron en conditions réelles sur le NAS.
+
+## Point de process notable : plusieurs itérations de cadrage en mode plan
+
+Cette issue a nécessité plusieurs allers-retours en mode plan avant validation (contrairement aux bugfixes habituels) car c'était une issue ouverte "à affiner". Points clés qui ont fait évoluer le plan initial :
+- Le choix d'hébergement ne pouvait pas être tranché sans connaître le plan long terme (multi-utilisateurs) de l'utilisateur — a nécessité une question explicite avant de proposer une architecture.
+- La question "comment le NAS reste synchro avec GitHub" a révélé qu'il fallait creuser l'existant (`ghcr.io/castorfou/lmelp-mobile-export`, `docker-compose.yml` de `docker-lmelp`) plutôt que d'inventer un nouveau mécanisme — l'utilisateur a explicitement demandé de vérifier s'il existait déjà un pattern anacron réutilisable (celui de `mongodb.Dockerfile`) avant de proposer une solution cron générique.
+- "Réseau optionnel" nécessitait d'être clarifié : ne signifie pas qu'aucun réseau n'est jamais utilisé, mais que son absence ne dégrade jamais l'usage normal — distinction importante à bien poser dans l'ADR.
+
+## Bug découvert pendant les tests manuels (hors scope, non traité)
+
+En testant l'écran À propos avec le nouvel affichage, l'utilisateur a constaté que `lmelp.db` embarqué dans l'app (committé dans le repo) est périmé : 179 émissions / dernière du 02/07/2026 alors que la vraie base a 180 émissions / dernière du 02/08/2026. Confirmé comme un problème de fraîcheur de données indépendant du code de cette PR (personne n'a relancé l'export récemment) — volontairement non corrigé dans cette PR, à traiter séparément via `python scripts/export_mongo_to_sqlite.py --force`.
+
+## Note de troubleshooting ADB (ajoutée à la doc)
+
+Symptôme observé : le téléphone est bien détecté par `lsusb`/gestionnaire de périphériques sur l'hôte, mais `adb devices` reste vide même après `adb kill-server && adb -a start-server`. Un simple **redémarrage du téléphone** a résolu le problème (cause exacte côté adb/udev non identifiée). Ajouté à `docs/dev/build_deploy_apk.md` dans la section troubleshooting ADB existante.

--- a/docs/dev/.nav.yml
+++ b/docs/dev/.nav.yml
@@ -6,3 +6,6 @@ nav:
   - État local utilisateur (DataStore): local-state-datastore.md
   - Android Auto: android-auto.md
   - Héritage PyFoundry: pyfoundry.md
+  - ADR:
+    - adr/README.md
+    - adr/0001-separation-maj-appli-donnees.md

--- a/docs/dev/adr/0001-separation-maj-appli-donnees.md
+++ b/docs/dev/adr/0001-separation-maj-appli-donnees.md
@@ -1,0 +1,87 @@
+# ADR 0001 — Séparer la mise à jour de l'application et la mise à jour des données
+
+- Statut : Accepté
+- Date : 2026-08-19
+- Issue : [#116](https://github.com/castorfou/lmelp-mobile/issues/116)
+
+## Contexte
+
+Le processus actuel de [mise à jour d'un épisode](../../user/mise_a_jour_episode.md) mélange deux préoccupations différentes derrière une seule commande ADB (`lmelp-update-mobile` → `docker exec lmelp-export export-and-push`) :
+
+- l'installation/mise à jour de l'**application** mobile elle-même (nouvelle fonctionnalité) — **rare**
+- la mise à jour des **données** (nouvel épisode ajouté à la base) — **fréquente** (~1x/semaine)
+
+ADB n'est en réalité nécessaire que pour le premier cas. De plus, le mécanisme actuel de remplacement de `lmelp.db` sur le téléphone dépend de `run-as`, qui n'est disponible que sur un build **debug** (`android:debuggable`) — il ne fonctionnerait jamais avec un APK release installé normalement par un utilisateur final.
+
+Élément déclencheur : la stack `docker-lmelp` migre vers un NAS Synology ([castorfou/docker-lmelp#47](https://github.com/castorfou/docker-lmelp/issues/47)). En usage courant, il n'y aura plus de laptop branché en USB au téléphone — le mécanisme ADB actuel devient impraticable pour la mise à jour des données, qui est pourtant le cas fréquent.
+
+## Décision
+
+### Flux de données (`lmelp.db`) — sujet principal, traité maintenant
+
+Publier `lmelp.db` comme **asset d'une GitHub Release dédiée aux données** (tag `data-latest`), distincte de la release APK (`vX.Y.Z`) :
+
+- Réutilise l'infrastructure CI existante — `release.yml` publie déjà l'APK de la même manière.
+- Zéro nouvelle infrastructure serveur à ce stade.
+- Un asset secondaire `metadata.json` (date d'export, nombre d'émissions/livres/avis, taille, SHA-256) est publié à côté du fichier, pour permettre une future vérification "y a-t-il une mise à jour ?" sans télécharger tout le fichier (~4-5 Mo).
+
+**Mécanisme de publication** : le container `lmelp-export` (image `ghcr.io/castorfou/lmelp-mobile-export`, buildée depuis `Dockerfile.export` dans ce repo) contient déjà `export_mongo_to_sqlite.py` + ADB et tourne en veille sur l'hôte Docker, piloté par `docker exec lmelp-export <commande>`. Une nouvelle commande `export-and-publish-release` (script `scripts/docker_export_and_publish_release.sh`) exporte, vérifie, génère `metadata.json` et publie sur GitHub via `gh release upload`.
+
+**Automatisation** : un job **anacron** est embarqué dans `Dockerfile.export`, suivant le même pattern déjà validé dans `mongodb.Dockerfile` (repo `docker-lmelp`, service `mongo`) pour la rotation de logs et le backup MongoDB. Anacron est choisi (plutôt que cron classique) précisément parce qu'un NAS/laptop peut être éteint aux heures programmées : anacron rattrape le job au prochain démarrage au lieu de le sauter. La commande `export-and-publish-release` reste aussi invocable manuellement.
+
+**Déclencheur côté app** (conception uniquement — implémentation dans une issue de suivi) : vérification **au lancement de l'app** (non bloquant, échec réseau silencieux) + **bouton manuel** "Vérifier les mises à jour", probablement dans l'écran À propos.
+
+**Contrainte non négociable** : l'app reste strictement **offline-first**. Le réseau est optionnel et best-effort — son absence ou son échec ne doit jamais bloquer ou dégrader l'usage normal de l'app (consultation des données déjà en local). La permission `INTERNET` est déjà présente dans le manifest (utilisée aujourd'hui pour les couvertures de livres via Coil) ; aucun changement de permission n'est nécessaire pour ce mécanisme.
+
+**Page technique version app/DB** (ajoutée par cette issue) : l'écran À propos (`AboutScreen.kt`), qui affiche déjà la version de l'app (commit Git, date de build) et un historique des commits, affiche désormais aussi les informations de la base locale (date d'export, nombre d'émissions/livres/avis) via `MetadataRepository.getDbInfo()` — déjà implémenté mais jusqu'ici jamais branché à l'UI. Combiné à une future vue côté serveur (voir Suivi), cela permet de comparer "ce que mon téléphone a" vs "ce qui est publié".
+
+### Flux application (APK) — point périphérique, hors scope technique ici
+
+Le mécanisme USB+ADB pour l'APK est lui aussi remis en cause par la migration NAS. Piste retenue comme direction future : publication sur le **Google Play Store**, qui résout nativement la distribution et la mise à jour de l'APK. Implications connues mais **non traitées dans cette issue** : compte développeur Google, processus de review, question des droits sur le contenu Le Masque et la Plume / France Inter diffusé dans l'app. Voir issue de suivi.
+
+Le sous-sujet "ADB sans fil depuis le NAS" (pairing debug sans fil Android 11+, `adb connect`) mentionné dans l'issue initiale devient obsolète pour le flux de données, remplacé par le téléchargement HTTP direct — strictement supérieur ici (pas de dépendance USB/pairing, fonctionne avec un build release). Il reste une piste possible pour un usage dev/debug ponctuel de déploiement APK sur un device de test — traité dans l'issue de suivi dédiée à la distribution APK, pas résolu ici.
+
+## Trajectoire court terme vs long terme
+
+**Court terme (cette issue + issues de suivi)** : GitHub Release asset, lecture seule, pas d'authentification, une base de données commune pour tous les utilisateurs de l'app (aujourd'hui : un seul utilisateur, l'auteur).
+
+**Long terme (projet séparé, non démarré, hors scope)** : l'auteur envisage de rendre le projet public avec :
+
+- multi-utilisateurs
+- un rôle admin qui met à jour la base commune des émissions (passées et futures)
+- un mode anonyme de consultation web + mobile
+- un mode utilisateur basé sur Calibre pour collecter les goûts (livres lus, notes) et permettre des recommandations personnalisées
+
+Ce futur backend nécessitera authentification, profils utilisateurs, et très probablement un vrai service HTTP/API — pas un simple asset statique. Il **remplacera** le mécanisme décrit ici. Cette décision ne ferme pas cette porte : le choix "GitHub Release asset" est explicitement une étape 1 pragmatique et temporaire. Le format `metadata.json` reste volontairement simple (JSON plat) pour ne pas sur-investir dans un format qui sera de toute façon remplacé par une vraie API plus tard.
+
+## Alternatives rejetées
+
+| Alternative | Raison du rejet |
+|---|---|
+| NAS statique seul (fichier servi en HTTP direct par le NAS, sans GitHub) | Nécessite d'exposer le NAS à Internet (reverse proxy, TLS, nom de domaine, sécurité) — infrastructure nouvelle à maintenir alors qu'une GitHub Release est déjà gratuite et en place. Envisageable plus tard si le volume/fréquence de données dépasse les limites GitHub Release, mais prématuré aujourd'hui. |
+| Service HTTP dédié tout de suite (API exposant `/lmelp.db` + endpoint de métadonnées) | Sur-ingénierie par rapport au besoin actuel (lecture seule, un seul éditeur de données). Anticipe le futur backend multi-utilisateurs sans que ses besoins réels (auth, modèle de données par utilisateur) soient encore connus — risque de travail jeté. À réévaluer quand le projet multi-utilisateurs démarrera réellement. |
+| ADB sans fil depuis le NAS (pairing debug sans fil Android 11+) | Résout génériquement "pousser un fichier sans USB" mais reste fragile (stabilité du pairing dans la durée, dépendance à un serveur ADB joignable en TCP) et exige un build debug (`run-as`) — ne fonctionnerait jamais avec un APK release installé normalement. Le HTTP direct est strictement supérieur pour ce cas d'usage. |
+
+## Conséquences
+
+**Positives :**
+
+- Découplage net : la mise à jour des données ne nécessite plus jamais ADB, USB, laptop ni build debug.
+- Réutilisation totale de l'infrastructure CI existante (`softprops/action-gh-release` déjà utilisé dans `release.yml`).
+- Chemin de migration clair vers un futur backend multi-utilisateurs, sans travail jeté.
+
+**Négatives / risques :**
+
+- GitHub Release asset n'a pas de mécanisme de delta/diff : chaque mise à jour télécharge le fichier complet (~4-5 Mo aujourd'hui). Acceptable au volume actuel ; à surveiller si la base grossit significativement.
+- Dépendance à la disponibilité de GitHub côté téléchargement — cohérent avec le caractère offline-first (l'app fonctionne sans, le téléchargement est un best-effort).
+- Le tag `data-latest` republié en continu ne conserve pas d'historique des versions de données dans les Releases GitHub — acceptable car `db_metadata`/`metadata.json` conservent `export_date`, et Git ne versionnait pas non plus les anciennes DB jusqu'ici.
+- Le déclenchement automatique dépend d'un token GitHub (`GH_TOKEN`, scope `contents:write`) provisionné côté NAS — nouveau secret à créer et sécuriser (voir issue de suivi `docker-lmelp`).
+
+## Suivi
+
+Issues créées dans le cadre de cette décision :
+
+1. [lmelp-mobile#118](https://github.com/castorfou/lmelp-mobile/issues/118) — implémentation Kotlin du téléchargement/vérification de `lmelp.db` côté app.
+2. [lmelp-mobile#119](https://github.com/castorfou/lmelp-mobile/issues/119) — faisabilité distribution APK (Google Play Store) et/ou ADB sans fil en dev/debug.
+3. [back-office-lmelp#262](https://github.com/castorfou/back-office-lmelp/issues/262) — visibilité côté serveur des versions app/DB déployées.
+4. [docker-lmelp#56](https://github.com/castorfou/docker-lmelp/issues/56) — provisioning du secret `GH_TOKEN` et validation de l'anacron en conditions réelles sur le NAS.

--- a/docs/dev/adr/README.md
+++ b/docs/dev/adr/README.md
@@ -1,0 +1,5 @@
+# Architecture Decision Records (ADR)
+
+Décisions d'architecture significatives pour lmelp-mobile, au format ADR léger (un fichier par décision).
+
+- [0001 — Séparer la mise à jour de l'application et la mise à jour des données](0001-separation-maj-appli-donnees.md)

--- a/docs/dev/build_deploy_apk.md
+++ b/docs/dev/build_deploy_apk.md
@@ -41,6 +41,8 @@ docker exec lmelp-export export-and-push
 
 L'image `ghcr.io/castorfou/lmelp-mobile-export` est publiée automatiquement depuis ce repo (CI/CD sur `Dockerfile.export`). Le service `lmelp-export` est configuré dans le repo `castorfou/docker-lmelp` ([issue #41](https://github.com/castorfou/docker-lmelp/issues/41)).
 
+> ⚠️ **Ce mécanisme ADB reste valable pour le déploiement APK en dev/debug**, mais n'est plus la cible pour la seule mise à jour des données : voir l'ADR [0001 — Séparer mise à jour appli / mise à jour données](adr/0001-separation-maj-appli-donnees.md) ([issue #116](https://github.com/castorfou/lmelp-mobile/issues/116)), qui décrit le passage à une publication `lmelp.db` en GitHub Release téléchargeable en HTTP, sans ADB.
+
 ## build apk depuis vscode
 
 ```bash
@@ -63,8 +65,7 @@ Si le device ne s'affiche pas :
 
 - un `adb kill-server` peut aider, revoquer les autorisations de debogage USB, et relancer `adb devices` (une popup d'autorisation doit arriver)
 - il faut aussi que le debogage USB soit active
-
-Parfois un reboot du téléphone peut aider.
+- **si `lsusb`/le gestionnaire de périphériques voit bien le téléphone mais que `adb devices` reste vide malgré `adb kill-server && adb -a start-server`** : redémarrer le téléphone résout souvent le problème (vécu régulièrement, cause exacte non identifiée côté adb/udev) — à essayer avant de creuser plus loin.
 
 
 ```bash

--- a/docs/user/mise_a_jour_episode.md
+++ b/docs/user/mise_a_jour_episode.md
@@ -1,5 +1,8 @@
 ## Ajouter l'épisode à la base de données LMELP
 
+!!! info "Évolution en cours"
+    La procédure ADB décrite plus bas pour mettre à jour la base sur le téléphone est en cours de remplacement par un téléchargement HTTP direct depuis l'application, sans branchement USB — voir l'[ADR 0001](../dev/adr/0001-separation-maj-appli-donnees.md) et l'[issue #116](https://github.com/castorfou/lmelp-mobile/issues/116). Cette page reste la procédure de référence tant que l'implémentation côté app n'est pas livrée ([issue #118](https://github.com/castorfou/lmelp-mobile/issues/118)).
+
 à la diffusion d'un nouvel épisode de l'émission, j'ai pas mal de boulot :
 
 > ![](img/favicon_lmelp-frontoffice.png) depuis **lmelp-frontoffice** :
@@ -146,5 +149,6 @@ Si `adb devices` ne voit pas le téléphone :
 - Vérifier que le mode USB est sur **Transfert de fichiers**
 - Valider la popup "Autoriser le débogage USB" sur le téléphone
 - En dernier recours : `adb kill-server && adb -a start-server`
+- En tout dernier recours : redémarre le téléphone, ça a solutionné plusieurs fois le problème
 
 Voir aussi [docs/dev/build_deploy_apk.md](../dev/build_deploy_apk.md) pour le diagnostic complet.

--- a/scripts/docker_export_and_publish_release.sh
+++ b/scripts/docker_export_and_publish_release.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# docker_export_and_publish_release.sh — Exporte lmelp.db et le publie en asset
+# de la GitHub Release "data-latest" (issue #116).
+#
+# Ce script tourne DANS le container lmelp-export (voir Dockerfile.export),
+# invoqué manuellement (docker exec lmelp-export export-and-publish-release)
+# ou automatiquement via le job anacron embarqué dans l'image.
+#
+# Contrairement à docker_export_and_push.sh (mécanisme ADB legacy, USB +
+# build debug), ce script ne dépend d'aucun accès au téléphone : il publie
+# la base sur GitHub, l'app la récupérera elle-même en HTTP (issue de suivi
+# lmelp-mobile#118).
+#
+# Variables d'environnement attendues :
+#   LMELP_MONGO_URI                  — URI MongoDB (ex: mongodb://mongo:27017)
+#   LMELP_CALIBRE_DB                 — chemin vers metadata.db dans le container
+#   LMELP_CALIBRE_VIRTUAL_LIBRARY    — tag virtual library Calibre (ex: guillaume)
+#   GH_TOKEN                         — token GitHub avec droit contents:write
+#                                       sur castorfou/lmelp-mobile (voir
+#                                       docker-lmelp#56 pour le provisioning)
+#   GH_REPO                          — repo cible (défaut: castorfou/lmelp-mobile)
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()    { echo -e "${BLUE}[INFO]${NC} $*"; }
+success() { echo -e "${GREEN}[OK]${NC}   $*"; }
+warn()    { echo -e "${YELLOW}[WARN]${NC} $*"; }
+die()     { echo -e "${RED}[ERR]${NC}  $*" >&2; exit 1; }
+
+DB_OUTPUT="/tmp/lmelp.db"
+METADATA_OUTPUT="/tmp/metadata.json"
+GH_REPO="${GH_REPO:-castorfou/lmelp-mobile}"
+
+echo -e "\n${BOLD}=== lmelp-mobile : Export et publication de la Release data-latest ===${NC}\n"
+
+# ---------------------------------------------------------------------------
+# 1. Vérifier les pré-requis
+# ---------------------------------------------------------------------------
+command -v gh >/dev/null 2>&1 || die "gh CLI introuvable dans le container"
+[[ -n "${GH_TOKEN:-}" ]] || die "GH_TOKEN non configuré (voir docker-lmelp#56)"
+
+# ---------------------------------------------------------------------------
+# 2. Vérifier Calibre (issue #42 : critique pour les données lu/rating)
+# ---------------------------------------------------------------------------
+CALIBRE_DB="${LMELP_CALIBRE_DB:-}"
+if [[ -z "$CALIBRE_DB" ]] || [[ ! -f "$CALIBRE_DB" ]]; then
+    warn "LMELP_CALIBRE_DB non configuré ou fichier absent : ${CALIBRE_DB:-<vide>}"
+    warn "Les données Calibre (lu/rating) seront absentes → filtre 'Lus' vide dans l'app"
+    CALIBRE_ARGS=""
+else
+    success "Calibre : $CALIBRE_DB"
+    CALIBRE_ARGS="--calibre-db ${CALIBRE_DB}"
+    if [[ -n "${LMELP_CALIBRE_VIRTUAL_LIBRARY:-}" ]]; then
+        CALIBRE_ARGS="$CALIBRE_ARGS --calibre-virtual-library ${LMELP_CALIBRE_VIRTUAL_LIBRARY}"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Export MongoDB → SQLite
+# ---------------------------------------------------------------------------
+info "Export MongoDB → SQLite..."
+MONGO_URI="${LMELP_MONGO_URI:-mongodb://mongo:27017}"
+
+python /app/scripts/export_mongo_to_sqlite.py \
+    --mongo-uri "$MONGO_URI" \
+    --output "$DB_OUTPUT" \
+    --force \
+    $CALIBRE_ARGS
+
+DB_SIZE=$(du -h "$DB_OUTPUT" | cut -f1)
+success "Base générée : $DB_OUTPUT ($DB_SIZE)"
+
+# ---------------------------------------------------------------------------
+# 4. Vérification d'intégrité
+# ---------------------------------------------------------------------------
+info "Vérification de l'intégrité..."
+python /app/scripts/export_mongo_to_sqlite.py --verify "$DB_OUTPUT"
+success "Vérification OK"
+
+# ---------------------------------------------------------------------------
+# 5. Génération des métadonnées
+# ---------------------------------------------------------------------------
+info "Génération de metadata.json..."
+python /app/scripts/generate_data_release_metadata.py \
+    --db "$DB_OUTPUT" \
+    --output "$METADATA_OUTPUT"
+success "Métadonnées générées : $METADATA_OUTPUT"
+
+# ---------------------------------------------------------------------------
+# 6. Publication sur GitHub Release "data-latest"
+# ---------------------------------------------------------------------------
+info "Publication sur ${GH_REPO} (release data-latest)..."
+
+if ! gh release view data-latest --repo "$GH_REPO" >/dev/null 2>&1; then
+    info "Release data-latest absente, création..."
+    gh release create data-latest \
+        --repo "$GH_REPO" \
+        --title "lmelp-mobile — données" \
+        --notes "Base de données lmelp, publiée automatiquement. Voir metadata.json pour la date d'export et le SHA-256."
+fi
+
+gh release upload data-latest "$DB_OUTPUT" "$METADATA_OUTPUT" \
+    --repo "$GH_REPO" \
+    --clobber
+
+success "=== Publication terminée avec succès ==="
+echo ""

--- a/scripts/generate_data_release_metadata.py
+++ b/scripts/generate_data_release_metadata.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Génère metadata.json pour une GitHub Release de données lmelp (issue #116).
+
+Le fichier metadata.json est publié comme asset secondaire à côté de lmelp.db
+sur la Release "data-latest". Il permet à une future implémentation app de
+vérifier si une mise à jour est disponible (via export_date/sha256) sans
+télécharger tout le fichier lmelp.db.
+
+Usage:
+    python scripts/generate_data_release_metadata.py --db lmelp.db --output metadata.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import sqlite3
+from pathlib import Path
+
+
+SCHEMA_VERSION = 1
+
+
+def compute_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(8192), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_db_metadata(db_path: Path) -> dict[str, str]:
+    con = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    try:
+        rows = con.execute("SELECT key, value FROM db_metadata").fetchall()
+    except sqlite3.OperationalError as exc:
+        raise ValueError(f"table db_metadata absente de {db_path}") from exc
+    finally:
+        con.close()
+
+    if not rows:
+        raise ValueError(f"table db_metadata vide dans {db_path}")
+
+    return dict(rows)
+
+
+def build_metadata(db_path: Path) -> dict:
+    db_meta = read_db_metadata(db_path)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "export_date": db_meta.get("export_date"),
+        "export_datetime": db_meta.get("export_datetime"),
+        "export_version": db_meta.get("version"),
+        "nb_emissions": int(db_meta.get("nb_emissions", 0)),
+        "nb_livres": int(db_meta.get("nb_livres", 0)),
+        "nb_avis": int(db_meta.get("nb_avis", 0)),
+        "file_size_bytes": db_path.stat().st_size,
+        "sha256": compute_sha256(db_path),
+        "filename": "lmelp.db",
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    args = parser.parse_args()
+
+    metadata = build_metadata(args.db)
+    args.output.write_text(json.dumps(metadata, indent=2, ensure_ascii=False))
+    print(f"metadata.json généré : {args.output}")
+    print(json.dumps(metadata, indent=2, ensure_ascii=False))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_generate_data_release_metadata.py
+++ b/tests/test_generate_data_release_metadata.py
@@ -1,0 +1,103 @@
+"""
+Tests du script scripts/generate_data_release_metadata.py.
+
+Ce script génère metadata.json à partir d'un lmelp.db, pour publication comme
+asset secondaire de la GitHub Release data-latest (voir issue #116 / ADR
+docs/dev/adr/0001-separation-maj-appli-donnees.md). metadata.json permet à une
+future implémentation app de vérifier si une mise à jour est disponible sans
+télécharger tout le fichier lmelp.db (~4-5 Mo).
+"""
+
+import hashlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from generate_data_release_metadata import build_metadata
+
+
+def _make_db(path, metadata: dict):
+    con = sqlite3.connect(path)
+    con.execute("CREATE TABLE db_metadata (key TEXT PRIMARY KEY, value TEXT)")
+    con.executemany(
+        "INSERT INTO db_metadata (key, value) VALUES (?, ?)",
+        list(metadata.items()),
+    )
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    path = tmp_path / "lmelp.db"
+    _make_db(
+        path,
+        {
+            "export_date": "2026-08-19",
+            "export_datetime": "2026-08-19T10:00:00",
+            "version": "1755600000",
+            "nb_emissions": "42",
+            "nb_livres": "123",
+            "nb_avis": "456",
+        },
+    )
+    return path
+
+
+class TestBuildMetadata:
+    def test_contient_les_champs_attendus(self, db_path):
+        metadata = build_metadata(db_path)
+
+        assert metadata["schema_version"] == 1
+        assert metadata["export_date"] == "2026-08-19"
+        assert metadata["export_datetime"] == "2026-08-19T10:00:00"
+        assert metadata["export_version"] == "1755600000"
+        assert metadata["nb_emissions"] == 42
+        assert metadata["nb_livres"] == 123
+        assert metadata["nb_avis"] == 456
+        assert metadata["filename"] == "lmelp.db"
+
+    def test_file_size_bytes_correspond_a_la_taille_reelle(self, db_path):
+        metadata = build_metadata(db_path)
+        assert metadata["file_size_bytes"] == db_path.stat().st_size
+
+    def test_sha256_correspond_au_contenu_du_fichier(self, db_path):
+        metadata = build_metadata(db_path)
+        expected = hashlib.sha256(db_path.read_bytes()).hexdigest()
+        assert metadata["sha256"] == expected
+
+    def test_sha256_change_si_le_contenu_change(self, db_path):
+        metadata_before = build_metadata(db_path)
+
+        con = sqlite3.connect(db_path)
+        con.execute(
+            "UPDATE db_metadata SET value = ? WHERE key = 'export_date'",
+            ("2026-08-20",),
+        )
+        con.commit()
+        con.close()
+
+        metadata_after = build_metadata(db_path)
+        assert metadata_after["sha256"] != metadata_before["sha256"]
+
+    def test_erreur_claire_si_db_metadata_absente(self, tmp_path):
+        path = tmp_path / "empty.db"
+        con = sqlite3.connect(path)
+        con.execute("CREATE TABLE autre_table (id INTEGER)")
+        con.commit()
+        con.close()
+
+        with pytest.raises(ValueError, match="db_metadata"):
+            build_metadata(path)
+
+    def test_erreur_claire_si_db_metadata_vide(self, tmp_path):
+        path = tmp_path / "vide.db"
+        _make_db(path, {})
+
+        with pytest.raises(ValueError, match="db_metadata"):
+            build_metadata(path)


### PR DESCRIPTION
## Résumé

- Décision d'architecture (ADR) pour séparer le flux de mise à jour de l'application (APK) du flux de mise à jour des données (`lmelp.db`), rendu nécessaire par la migration de `docker-lmelp` vers un NAS (plus de laptop USB en usage courant).
- Squelette CI minimal : publication de `lmelp.db` en asset d'une GitHub Release dédiée (`data-latest`), avec `metadata.json` (export_date, SHA-256, compteurs) pour une future vérification de MAJ sans tout télécharger.
- Automatisation via anacron dans `Dockerfile.export`, réutilisant le pattern déjà validé dans `mongodb.Dockerfile` (repo `docker-lmelp`).
- Petit ajout UI : l'écran À propos affiche désormais la version des données locales (date d'export, nb émissions/livres/avis), en plus de la version app déjà affichée.
- Correction d'une confusion documentée dans `CLAUDE.md` entre `PRAGMA user_version` (numéro de schéma Room fixe) et le timestamp d'export réel (`db_metadata.version`).

L'implémentation Kotlin du téléchargement effectif côté app est explicitement hors scope — voir les issues de suivi créées.

Closes #116

## Issues de suivi créées

- #118 — implémentation Kotlin du téléchargement/vérification de `lmelp.db` côté app
- #119 — faisabilité distribution APK (Play Store) et/ou ADB sans fil en dev/debug
- castorfou/back-office-lmelp#262 — visibilité côté serveur des versions app/DB déployées
- castorfou/docker-lmelp#56 — provisioning du secret `GH_TOKEN` + validation anacron sur le NAS

## Test plan

- [x] Tests Python : `pytest tests/` (62 passed, 2 skipped — MongoDB indisponible en local)
- [x] `ruff check` / `ruff format --check` / `mypy` sur le nouveau code Python
- [x] Tests Kotlin : `./gradlew testDebugUnitTest` (build + tests unitaires OK, incluant les nouveaux `DbInfoFormatterTest`)
- [x] `./gradlew lint` clean
- [x] `mkdocs build --strict` — ADR intégré à la nav sans erreur
- [x] Testé manuellement sur device : nouvel écran À propos affiche bien la section "Données"
- [x] CI GitHub Actions verte sur la branche (tests Python 3.11/3.12, Android build/tests, pre-commit hooks)
- [ ] `build-export-image.yml` se déclenchera à l'ouverture de cette PR (trigger `pull_request` sur modif de `Dockerfile.export`) — à vérifier une fois la PR ouverte

🤖 Generated with [Claude Code](https://claude.com/claude-code)